### PR TITLE
Add support for more translations with tests and documentation

### DIFF
--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::frame::Frame;
 mod frame_mut;
 pub use self::frame_mut::FrameMut;
 
-mod translate;
+pub mod translate;
 pub use self::translate::Translate;
 
 mod sample;

--- a/audio-core/src/translate.rs
+++ b/audio-core/src/translate.rs
@@ -1,7 +1,43 @@
+//! Utility traits for dealing with sample translations.
+//!
+//! Primitive samples are encoded with PCM which have a midpoint of no amplitude
+//! (i.e. silence). The possible primitives are as follows:
+//!
+//! * Unsigned samples have a span from 0 as its *highest negative* amplitude to
+//!   maximum as its *highest positive* amplitude. The midpoint is defined as
+//!   its `(max + 1) / 2` such as `0x8000` for `u16` or `0x80000000` for `u32`.
+//! * Signed samples have a midpoint at 0 and utilises the full range of the
+//!   type where its minimum is the *highest negative* amplitude and its maximum
+//!   is its *highest positive* amplitude.
+//! * Float samples have a midpoint at `0.0` and utilises the range `-1.0` to
+//!   `1.0` (inclusive).
+//!
+//! These rules are applied to the following *native* Rust types:
+//!
+//! * `u8`, `u16`, `u32`, and `u64` for unsigned PCM 8 to 64 bit audio
+//!   modulation.
+//! * `i8`, `i16`, `i32`, and `i64` for signed PCM 8 to 64 bit audio modulation.
+//! * `f32` and `f64` for 32 and 64 bit PCM floating-point audio modulation.
+//!
+//! The primary traits that govern how something is translated are the
+//! [Translate] and [TryTranslate]. The first deals with non-fallible
+//! translations where conversion loss is expected (as with float-integer
+//! translations). [TryTranslate] deals with translations where an unexpected
+//! loss in precision would otherwise occur.
+//!
+//! See the documentation for each trait for more information.
+
+use core::convert::Infallible;
+
 #[cfg(test)]
 mod tests;
 
 /// Trait used for translating one sample type to another.
+///
+/// This performs infallible translations where any loss in precision is
+/// *expected* and is not supported between types which cannot be universally
+/// translated in this manner such as translations from a higher to a lower
+/// precision format.
 ///
 /// # Examples
 ///
@@ -14,10 +50,51 @@ mod tests;
 /// assert_eq!(u16::translate(-1.0f32), u16::MIN);
 /// assert_eq!(u16::translate(0.0f32), 32768);
 /// ```
-pub trait Translate<T> {
+pub trait Translate<T>: Sized {
     /// Translate one kind of buffer to another.
     fn translate(value: T) -> Self;
 }
+
+/// Trait for performing checked translations, where it's checked if a
+/// translation would result in loss of precision.
+///
+/// This will fail if we try to perform a translation between two integer types
+/// which are not exactly equivalent.
+///
+/// # Examples
+///
+/// ```
+/// use audio::translate::{TryTranslate, IntTranslationError};
+///
+/// assert_eq!(i16::try_translate(-1.0f32), Ok(i16::MIN));
+/// assert_eq!(i16::try_translate(i32::MIN), Ok(i16::MIN));
+/// assert_eq!(i16::try_translate(0x70000000i32), Ok(0x7000i16));
+/// assert!(matches!(i16::try_translate(0x70000001i32), Err(IntTranslationError { .. })));
+/// ```
+pub trait TryTranslate<T>: Sized {
+    /// Error kind raised from the translation.
+    type Err;
+
+    /// Perform a conversion.
+    fn try_translate(value: T) -> Result<Self, Self::Err>;
+}
+
+impl<T, U> TryTranslate<T> for U
+where
+    U: Translate<T>,
+{
+    type Err = Infallible;
+
+    #[inline]
+    fn try_translate(value: T) -> Result<Self, Self::Err> {
+        Ok(U::translate(value))
+    }
+}
+
+/// Unable to translate an integer due to loss of precision.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IntTranslationError;
 
 macro_rules! identity {
     ($ty:ty) => {
@@ -30,49 +107,15 @@ macro_rules! identity {
     };
 }
 
-macro_rules! int_to_float {
-    ($signed:ident, $unsigned:ident, $float:ident) => {
-        impl Translate<$signed> for $float {
-            #[inline]
-            fn translate(value: $signed) -> Self {
-                // Needs special care to avoid distortion at the cost of not
-                // covering the whole range.
-                // See: https://github.com/udoprog/audio/issues/7
-                -(value as $float) / ($signed::MIN as $float)
-            }
-        }
+macro_rules! conversions {
+    (
+        $signed:ty, $unsigned:ty,
+        {$($float:ty),* $(,)?},
+        {$([$lossless_unsigned:ty, $lossless_signed:ty, $lossless_shift:expr]),* $(,)?}
+    ) => {
+        identity!($signed);
+        identity!($unsigned);
 
-        impl Translate<$float> for $signed {
-            #[inline]
-            fn translate(value: $float) -> Self {
-                // Needs special care to avoid distortion at the cost of not
-                // covering the whole range.
-                // See: https://github.com/udoprog/audio/issues/7
-                -(value * $signed::MIN as $float) as $signed
-            }
-        }
-
-        #[cfg(feature = "std")]
-        impl Translate<$float> for $unsigned {
-            #[inline]
-            fn translate(value: $float) -> Self {
-                // Go through signed to get the same float conversion.
-                $unsigned::translate($signed::translate(value))
-            }
-        }
-
-        impl Translate<$unsigned> for $float {
-            #[inline]
-            fn translate(value: $unsigned) -> Self {
-                // Go through signed to get the same float conversion.
-                $float::translate($signed::translate(value))
-            }
-        }
-    };
-}
-
-macro_rules! signed_to_unsigned {
-    ($signed:ty, $unsigned:ty) => {
         impl Translate<$unsigned> for $signed {
             #[inline]
             fn translate(value: $unsigned) -> Self {
@@ -86,23 +129,124 @@ macro_rules! signed_to_unsigned {
                 value.wrapping_add(<$signed>::MIN) as $unsigned
             }
         }
+
+        $(
+        impl Translate<$lossless_unsigned> for $unsigned {
+            #[inline]
+            fn translate(value: $lossless_unsigned) -> Self {
+                (value as $unsigned).wrapping_shl($lossless_shift)
+            }
+        }
+
+        impl Translate<$lossless_signed> for $unsigned {
+            #[inline]
+            fn translate(value: $lossless_signed) -> Self {
+                <$unsigned>::translate(<$lossless_unsigned>::translate(value))
+            }
+        }
+
+        impl Translate<$lossless_signed> for $signed {
+            #[inline]
+            fn translate(value: $lossless_signed) -> Self {
+                (value as $signed).wrapping_shl($lossless_shift)
+            }
+        }
+
+        impl Translate<$lossless_unsigned> for $signed {
+            #[inline]
+            fn translate(value: $lossless_unsigned) -> Self {
+                <$signed>::translate(<$lossless_signed>::translate(value))
+            }
+        }
+
+        impl TryTranslate<$unsigned> for $lossless_unsigned {
+            type Err = IntTranslationError;
+
+            #[inline]
+            fn try_translate(value: $unsigned) -> Result<Self, Self::Err> {
+                if value & ((1 << $lossless_shift) - 1) != 0 {
+                    return Err(IntTranslationError);
+                }
+
+                Ok(value.wrapping_shr($lossless_shift) as $lossless_unsigned)
+            }
+        }
+
+        impl TryTranslate<$signed> for $lossless_unsigned {
+            type Err = IntTranslationError;
+
+            #[inline]
+            fn try_translate(value: $signed) -> Result<Self, Self::Err> {
+                <$lossless_unsigned>::try_translate(<$unsigned>::translate(value))
+            }
+        }
+
+        impl TryTranslate<$signed> for $lossless_signed {
+            type Err = IntTranslationError;
+
+            #[inline]
+            fn try_translate(value: $signed) -> Result<Self, Self::Err> {
+                if value & ((1 << $lossless_shift) - 1) != 0 {
+                    return Err(IntTranslationError);
+                }
+
+                Ok(value.wrapping_shr($lossless_shift) as $lossless_signed)
+            }
+        }
+
+        impl TryTranslate<$unsigned> for $lossless_signed {
+            type Err = IntTranslationError;
+
+            #[inline]
+            fn try_translate(value: $unsigned) -> Result<Self, Self::Err> {
+                <$lossless_signed>::try_translate(<$signed>::translate(value))
+            }
+        }
+        )*
+
+        $(
+        impl Translate<$signed> for $float {
+            #[inline]
+            fn translate(value: $signed) -> Self {
+                // Needs special care to avoid distortion at the cost of not
+                // covering the whole range.
+                // See: https://github.com/udoprog/audio/issues/7
+                -(value as $float) / (<$signed>::MIN as $float)
+            }
+        }
+
+        impl Translate<$float> for $signed {
+            #[inline]
+            fn translate(value: $float) -> Self {
+                // Needs special care to avoid distortion at the cost of not
+                // covering the whole range.
+                // See: https://github.com/udoprog/audio/issues/7
+                -(value * <$signed>::MIN as $float) as $signed
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl Translate<$float> for $unsigned {
+            #[inline]
+            fn translate(value: $float) -> Self {
+                // Go through signed to get the same float conversion.
+                <$unsigned>::translate(<$signed>::translate(value))
+            }
+        }
+
+        impl Translate<$unsigned> for $float {
+            #[inline]
+            fn translate(value: $unsigned) -> Self {
+                // Go through signed to get the same float conversion.
+                <$float>::translate(<$signed>::translate(value))
+            }
+        }
+        )*
     };
 }
 
 identity!(f32);
 identity!(f64);
-identity!(i16);
-identity!(u16);
-identity!(u8);
-
-int_to_float!(i16, u16, f32);
-int_to_float!(i16, u16, f64);
-
-int_to_float!(i8, u8, f32);
-int_to_float!(i8, u8, f64);
-
-signed_to_unsigned!(i16, u16);
-signed_to_unsigned!(i8, u8);
 
 impl Translate<f32> for f64 {
     #[inline]
@@ -117,3 +261,8 @@ impl Translate<f64> for f32 {
         value as f32
     }
 }
+
+conversions!(i64, u64, {f32, f64}, {[u8, i8, 56], [u16, i16, 48], [u32, i32, 32]});
+conversions!(i32, u32, {f32, f64}, {[u8, i8, 24], [u16, i16, 16]});
+conversions!(i16, u16, {f32, f64}, {[u8, i8, 8]});
+conversions!(i8, u8, {f32, f64}, {});

--- a/audio-core/src/translate/tests.rs
+++ b/audio-core/src/translate/tests.rs
@@ -1,72 +1,228 @@
-use crate::translate::Translate;
+use crate::translate::{IntTranslationError, Translate, TryTranslate};
 
-macro_rules! test_int_mids {
+macro_rules! assert_mid_ok {
     ($ty:ty, $mid:expr) => {
-        assert_eq!(<$ty>::translate(32768u16), $mid);
-        assert_eq!(<$ty>::translate(0i16), $mid);
-        assert_eq!(<$ty>::translate(0.0f32), $mid);
-        assert_eq!(<$ty>::translate(0.0f64), $mid);
-    };
-}
-
-macro_rules! test_int {
-    ($ty:ident, $min:expr, $max:expr) => {
-        assert_eq!(<$ty>::translate(1.0f32), $max);
-        assert_eq!(<$ty>::translate(-1.0f32), $min);
-
-        assert_eq!(<$ty>::translate(1.0f64), $max);
-        assert_eq!(<$ty>::translate(-1.0f64), $min);
-
-        assert_eq!(<$ty>::translate(u16::MIN), $min);
-        assert_eq!(<$ty>::translate(u16::MAX), $max);
-
-        assert_eq!(<$ty>::translate(i16::MIN), $min);
-        assert_eq!(<$ty>::translate(i16::MAX), $max);
+        let mid: $ty = $mid;
+        assert_eq!(<$ty>::try_translate(0.0f32).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0.0f64).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0x80u8).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0i8).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0x8000u16).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0i16).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0x80000000u32).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0i32).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0x8000000000000000u64).unwrap(), mid);
+        assert_eq!(<$ty>::try_translate(0i64).unwrap(), mid);
     };
 }
 
 #[test]
-fn test_u16_translations() {
-    test_int_mids!(u16, 32768);
-    test_int!(u16, u16::MIN, u16::MAX);
+fn test_translation_mids() {
+    assert_mid_ok!(u8, 0x80);
+    assert_mid_ok!(u16, 0x8000);
+    assert_mid_ok!(u32, 0x80000000);
+    assert_mid_ok!(u64, 0x8000000000000000);
+    assert_mid_ok!(i8, 0);
+    assert_mid_ok!(i16, 0);
+    assert_mid_ok!(i32, 0);
+    assert_mid_ok!(i64, 0);
+    assert_mid_ok!(f32, 0.0);
+    assert_mid_ok!(f64, 0.0);
 }
 
-#[test]
-fn test_i16_translations() {
-    test_int_mids!(i16, 0);
-    test_int!(i16, i16::MIN, i16::MAX);
-}
-
-macro_rules! test_float {
-    ($ty:ident, $min:expr, $max:expr, $int_max:expr) => {
-        assert_eq!(<$ty>::translate(1.0f32), $max);
-        assert_eq!(<$ty>::translate(-1.0f32), $min);
-
-        assert_eq!(<$ty>::translate(1.0f64), $max);
-        assert_eq!(<$ty>::translate(-1.0f64), $min);
-
-        assert_eq!(<$ty>::translate(u16::MIN), $min);
-        assert_eq!(<$ty>::translate(u16::MAX), $int_max);
-        assert_eq!(<u16>::translate($int_max), u16::MAX);
-
-        assert_eq!(<$ty>::translate(i16::MIN), $min);
-        assert_eq!(<$ty>::translate(i16::MAX), $int_max);
-        assert_eq!(<i16>::translate($int_max), i16::MAX);
+macro_rules! assert_min_ok {
+    ($ty:ty, $min:expr) => {
+        let min: $ty = $min;
+        assert_eq!(<$ty>::try_translate(-1.0f32).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(-1.0f64).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(0u8).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(i8::MIN).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(0u16).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(i16::MIN).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(0u32).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(i32::MIN).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(0u64).unwrap(), min);
+        assert_eq!(<$ty>::try_translate(i64::MIN).unwrap(), min);
     };
 }
 
 #[test]
-fn test_f32_translations() {
-    // NB: integer max to float translations are not expected to cover the whole
-    // range.
+fn test_translation_minimums() {
+    assert_min_ok!(u8, 0);
+    assert_min_ok!(u16, 0);
+    assert_min_ok!(u32, 0);
+    assert_min_ok!(u64, 0);
+    assert_min_ok!(i8, i8::MIN);
+    assert_min_ok!(i16, i16::MIN);
+    assert_min_ok!(i32, i32::MIN);
+    assert_min_ok!(i64, i64::MIN);
+    assert_min_ok!(f32, -1.0);
+    assert_min_ok!(f64, -1.0);
+}
+
+macro_rules! assert_int_max {
+    ($ty:ident, $max:expr, $other_ty:ty, $other_max:expr) => {
+        assert_eq!(<$ty>::try_translate($other_max), Ok($max));
+        assert_eq!(<$other_ty>::try_translate($max), Ok($other_max));
+    };
+}
+
+macro_rules! assert_float_max {
+    ($ty:ident, $u8_max:expr, $u16_max:expr, $u32_max:expr, $u64_max:expr) => {
+        let max: $ty = 1.0;
+        assert_eq!(<$ty>::translate(1.0f32), max);
+        assert_eq!(<$ty>::translate(1.0f64), max);
+
+        assert_eq!(<$ty>::translate(u8::MAX), $u8_max);
+        assert_eq!(<u8>::translate($u8_max), u8::MAX);
+        assert_eq!(<$ty>::translate(i8::MAX), $u8_max);
+        assert_eq!(<i8>::translate($u8_max), i8::MAX);
+
+        assert_eq!(<$ty>::translate(u16::MAX), $u16_max);
+        assert_eq!(<u16>::translate($u16_max), u16::MAX);
+        assert_eq!(<$ty>::translate(i16::MAX), $u16_max);
+        assert_eq!(<i16>::translate($u16_max), i16::MAX);
+
+        assert_eq!(<$ty>::translate(u32::MAX), $u32_max);
+        assert_eq!(<u32>::translate($u32_max), u32::MAX);
+        assert_eq!(<$ty>::translate(i32::MAX), $u32_max);
+        assert_eq!(<i32>::translate($u32_max), i32::MAX);
+
+        assert_eq!(<$ty>::translate(u64::MAX), $u64_max);
+        assert_eq!(<u64>::translate($u64_max), u64::MAX);
+        assert_eq!(<$ty>::translate(i64::MAX), $u64_max);
+        assert_eq!(<i64>::translate($u64_max), i64::MAX);
+    };
+}
+
+#[test]
+fn test_maximums() {
+    // NB: inprecise integer translations are not expected to cover the whole
+    // range of a type.
     // See: https://github.com/udoprog/audio/issues/7
-    test_float!(f32, -1.0, 1.0, 0.9999695);
+
+    assert_float_max!(f32, 0.9921875, 0.9999695, 1.0, 1.0);
+    assert_float_max!(f64, 0.9921875, 0.999969482421875, 0.9999999995343387, 1.0);
+
+    assert_int_max!(u8, u8::MAX, u16, (u8::MAX as u16) << 8);
+    assert_int_max!(u8, u8::MAX, u32, (u8::MAX as u32) << 24);
+    assert_int_max!(u8, u8::MAX, u64, (u8::MAX as u64) << 56);
+    assert_int_max!(u16, u16::MAX, u32, (u16::MAX as u32) << 16);
+    assert_int_max!(u16, u16::MAX, u64, (u16::MAX as u64) << 48);
+    assert_int_max!(u32, u32::MAX, u64, (u32::MAX as u64) << 32);
+}
+
+macro_rules! assert_ok {
+    ($in_ty:ty, $in:expr, $out_ty:ty, $out:expr) => {
+        let o: $out_ty = $out;
+        let i: $in_ty = $in;
+        assert_eq!(<$out_ty>::translate(i), o);
+        assert_eq!(<$in_ty>::try_translate(o).unwrap(), i);
+    };
 }
 
 #[test]
-fn test_f64_translations() {
-    // NB: integer max to float translations are not expected to cover the whole
-    // range.
-    // See: https://github.com/udoprog/audio/issues/7
-    test_float!(f64, -1.0, 1.0, 0.999969482421875);
+fn test_lossless_unsigned() {
+    assert_ok!(u8, 0, u16, 0);
+    assert_ok!(u8, u8::MAX, u16, (u8::MAX as u16) << 8);
+    assert_ok!(u8, u8::MIN, u16, u16::MIN);
+
+    assert_ok!(u16, 0, u16, 0);
+    assert_ok!(u16, u16::MAX, u16, u16::MAX);
+    assert_ok!(u16, u16::MIN, u16, u16::MIN);
+
+    assert_ok!(u8, 0, u32, 0);
+    assert_ok!(u8, u8::MAX, u32, (u8::MAX as u32) << 24);
+    assert_ok!(u8, u8::MIN, u32, u32::MIN);
+
+    assert_ok!(u16, 0u16, u32, 0u32);
+    assert_ok!(u16, u16::MAX, u32, (u16::MAX as u32) << 16);
+    assert_ok!(u16, u16::MIN, u32, u32::MIN);
+
+    assert_ok!(u32, u32::MAX, u32, u32::MAX);
+    assert_ok!(u32, u32::MIN, u32, u32::MIN);
+
+    assert_ok!(u8, 0, u64, 0);
+    assert_ok!(u8, u8::MAX, u64, (u8::MAX as u64) << 56);
+    assert_ok!(u8, u8::MIN, u64, u64::MIN);
+
+    assert_ok!(u16, 0, u64, 0);
+    assert_ok!(u16, u16::MAX, u64, (u16::MAX as u64) << 48);
+    assert_ok!(u16, u16::MIN, u64, u64::MIN);
+
+    assert_ok!(u32, 0, u64, 0);
+    assert_ok!(u32, u32::MAX, u64, (u32::MAX as u64) << 32);
+    assert_ok!(u32, u32::MIN, u64, u64::MIN);
+
+    assert_ok!(u64, 0, u64, 0);
+    assert_ok!(u64, u64::MAX, u64, u64::MAX);
+    assert_ok!(u64, u64::MIN, u64, u64::MIN);
+}
+
+#[test]
+fn test_lossless_signed() {
+    assert_ok!(i8, 0, i16, 0);
+    assert_ok!(i8, 0x13, i16, 0x1300);
+    assert_ok!(i8, -0x13, i16, -0x1300);
+    assert_ok!(i8, i8::MAX, i16, (i8::MAX as i16) << 8);
+    assert_ok!(i8, i8::MIN, i16, i16::MIN);
+
+    assert_ok!(i8, 0, i32, 0);
+    assert_ok!(i8, 0x13, i32, 0x13000000);
+    assert_ok!(i8, -0x13, i32, -0x13000000);
+    assert_ok!(i8, i8::MAX, i32, (i8::MAX as i32) << 24);
+    assert_ok!(i8, i8::MIN, i32, i32::MIN);
+
+    assert_ok!(i16, 0, i32, 0);
+    assert_ok!(i16, 0x13, i32, 0x130000);
+    assert_ok!(i16, 0x1337, i32, 0x13370000);
+    assert_ok!(i16, -0x13, i32, -0x130000);
+    assert_ok!(i16, -0x1337, i32, -0x13370000);
+    assert_ok!(i16, i16::MAX, i32, (i16::MAX as i32) << 16);
+    assert_ok!(i16, i16::MIN, i32, i32::MIN);
+
+    assert_ok!(i8, 0, i64, 0);
+    assert_ok!(i8, 0x13, i64, 0x1300000000000000);
+    assert_ok!(i8, -0x13, i64, -0x1300000000000000);
+    assert_ok!(i8, i8::MAX, i64, (i8::MAX as i64) << 56);
+    assert_ok!(i8, i8::MIN, i64, i64::MIN);
+
+    assert_ok!(i16, 0, i64, 0);
+    assert_ok!(i16, 0x1337, i64, 0x1337000000000000);
+    assert_ok!(i16, -0x1337, i64, -0x1337000000000000);
+    assert_ok!(i16, i16::MAX, i64, (i16::MAX as i64) << 48);
+    assert_ok!(i16, i16::MIN, i64, i64::MIN);
+
+    assert_ok!(i32, 0, i64, 0);
+    assert_ok!(i32, 0x1337, i64, 0x133700000000);
+    assert_ok!(i32, -0x1337, i64, -0x133700000000);
+    assert_ok!(i32, i32::MAX, i64, (i32::MAX as i64) << 32);
+    assert_ok!(i32, i32::MIN, i64, i64::MIN);
+}
+
+macro_rules! assert_err {
+    ($in_ty:ty, $in:expr => $ty:ty) => {
+        let o: $in_ty = $in;
+        assert_eq!(<$ty>::try_translate(o), Err(IntTranslationError));
+    };
+}
+
+#[test]
+fn test_failing_unsigned() {
+    assert_err!(u16, 0x1301 => u8);
+    assert_err!(u32, 0x13000001 => u8);
+    assert_err!(u64, 0x1300000000000001 => u8);
+    assert_err!(u32, 0x13000001 => u16);
+    assert_err!(u64, 0x1300000000000001 => u16);
+    assert_err!(u64, 0x1300000000000001 => u32);
+}
+
+#[test]
+fn test_failing_signed() {
+    assert_err!(i16, 0x1301 => i8);
+    assert_err!(i32, 0x13000001 => i8);
+    assert_err!(i64, 0x1300000000000001 => i8);
+    assert_err!(i32, 0x13000001 => i16);
+    assert_err!(i64, 0x1300000000000001 => i16);
+    assert_err!(i64, 0x1300000000000001 => i32);
 }


### PR DESCRIPTION
Following #7 this expands integer translations and experimentally incorporates fallible translations through `TryTranslate`.

The `translate` module has also been made public with a bit of documentation on what a sample translation actually is.