### PR TITLE
Make API explicit about what it's getting/iterating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-      fail-fast: false
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -17,6 +13,17 @@ jobs:
         override: true
     - uses: Swatinem/rust-cache@v2
     - run: cargo test --all-features -p audio -p audio-core -p audio-generator -p ste
+
+  build-no-std:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test --no-default-features -p audio -p audio-core
 
   build-wasapi:
     runs-on: windows-latest

--- a/audio-core/src/buf.rs
+++ b/audio-core/src/buf.rs
@@ -46,7 +46,7 @@ pub trait Buf {
         Self: 'this;
 
     /// An iterator over available channels.
-    type Iter<'this>: Iterator<Item = Self::Channel<'this>>
+    type IterChannels<'this>: Iterator<Item = Self::Channel<'this>>
     where
         Self: 'this;
 
@@ -81,8 +81,8 @@ pub trait Buf {
     ///     assert_eq!(buf.channels(), 2);
     ///     assert_eq!(buf.frames_hint(), Some(4));
     ///
-    ///     assert_eq!(buf.get(0).map(|c| c.len()), Some(4));
-    ///     assert_eq!(buf.get(1).map(|c| c.len()), Some(2));
+    ///     assert_eq!(buf.get_channel(0).map(|c| c.len()), Some(4));
+    ///     assert_eq!(buf.get_channel(1).map(|c| c.len()), Some(2));
     /// }
     ///
     /// test(audio::wrap::dynamic(vec![vec![1, 2, 3, 4], vec![5, 6]]));
@@ -100,12 +100,12 @@ pub trait Buf {
     ///     assert_eq!(buf.channels(), 2);
     ///
     ///     assert_eq! {
-    ///         buf.get(0).unwrap().iter().collect::<Vec<_>>(),
+    ///         buf.get_channel(0).unwrap().iter().collect::<Vec<_>>(),
     ///         &[1, 2, 3, 4],
     ///     }
     ///
     ///     assert_eq! {
-    ///         buf.get(1).unwrap().iter().collect::<Vec<_>>(),
+    ///         buf.get_channel(1).unwrap().iter().collect::<Vec<_>>(),
     ///         &[5, 6, 7, 8],
     ///     }
     /// }
@@ -131,7 +131,7 @@ pub trait Buf {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: impl Buf<Sample = i16>) {
-    ///     let chan = buf.get(1).unwrap();
+    ///     let chan = buf.get_channel(1).unwrap();
     ///     chan.iter().eq([5, 6, 7, 8]);
     /// }
     ///
@@ -139,7 +139,7 @@ pub trait Buf {
     /// test(audio::sequential![[1, 2, 3, 4], [5, 6, 7, 8]]);
     /// test(audio::interleaved![[1, 2, 3, 4], [5, 6, 7, 8]]);
     /// ```
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>>;
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>>;
 
     /// Construct an iterator over all the channels in the audio buffer.
     ///
@@ -149,7 +149,7 @@ pub trait Buf {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: impl Buf<Sample = i16>) {
-    ///     let chan = buf.iter().nth(1).unwrap();
+    ///     let chan = buf.iter_channels().nth(1).unwrap();
     ///     chan.iter().eq([5, 6, 7, 8]);
     /// }
     ///
@@ -157,7 +157,7 @@ pub trait Buf {
     /// test(audio::sequential![[1, 2, 3, 4], [5, 6, 7, 8]]);
     /// test(audio::interleaved![[1, 2, 3, 4], [5, 6, 7, 8]]);
     /// ```
-    fn iter(&self) -> Self::Iter<'_>;
+    fn iter_channels(&self) -> Self::IterChannels<'_>;
 
     /// Construct a wrapper around this buffer that skips the first `n` frames.
     ///
@@ -228,7 +228,7 @@ pub trait Buf {
     /// assert_eq!((&buf).tail(5).channels(), 2);
     /// assert_eq!((&buf).tail(5).frames_hint(), Some(4));
     ///
-    /// for chan in buf.tail(2).iter() {
+    /// for chan in buf.tail(2).iter_channels() {
     ///     assert!(chan.iter().eq([3, 4]));
     /// }
     /// ```
@@ -272,7 +272,7 @@ pub trait Buf {
     /// assert_eq!((&buf).limit(5).channels(), 2);
     /// assert_eq!((&buf).limit(5).frames_hint(), Some(4));
     ///
-    /// for chan in buf.limit(2).iter() {
+    /// for chan in buf.limit(2).iter_channels() {
     ///     assert!(chan.iter().eq([1, 2]));
     /// }
     /// ```
@@ -294,7 +294,7 @@ where
     where
         Self: 'a;
 
-    type Iter<'a> = B::Iter<'a>
+    type IterChannels<'a> = B::IterChannels<'a>
     where
         Self: 'a;
 
@@ -309,13 +309,13 @@ where
     }
 
     #[inline]
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        (**self).get(channel)
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        (**self).get_channel(channel)
     }
 
     #[inline]
-    fn iter(&self) -> Self::Iter<'_> {
-        (**self).iter()
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
+        (**self).iter_channels()
     }
 }
 
@@ -329,7 +329,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = B::Iter<'this>
+    type IterChannels<'this> = B::IterChannels<'this>
     where
         Self: 'this;
 
@@ -344,12 +344,12 @@ where
     }
 
     #[inline]
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        (**self).get(channel)
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        (**self).get_channel(channel)
     }
 
     #[inline]
-    fn iter(&self) -> Self::Iter<'_> {
-        (**self).iter()
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
+        (**self).iter_channels()
     }
 }

--- a/audio-core/src/buf/limit.rs
+++ b/audio-core/src/buf/limit.rs
@@ -25,7 +25,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<B::Iter<'this>>
+    type IterChannels<'this> = IterChannels<B::IterChannels<'this>>
     where
         Self: 'this;
 
@@ -38,13 +38,13 @@ where
         self.buf.channels()
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        Some(self.buf.get(channel)?.limit(self.limit))
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        Some(self.buf.get_channel(channel)?.limit(self.limit))
     }
 
-    fn iter(&self) -> Self::Iter<'_> {
-        Iter {
-            iter: self.buf.iter(),
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
+        IterChannels {
+            iter: self.buf.iter_channels(),
             limit: self.limit,
         }
     }
@@ -58,12 +58,12 @@ where
     where
         Self: 'this;
 
-    type IterMut<'this> = IterMut<B::IterMut<'this>>
+    type IterChannelsMut<'this> = IterChannelsMut<B::IterChannelsMut<'this>>
     where
         Self: 'this;
 
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.limit(self.limit))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.limit(self.limit))
     }
 
     fn copy_channel(&mut self, from: usize, to: usize)
@@ -73,9 +73,9 @@ where
         self.buf.copy_channel(from, to);
     }
 
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        IterMut {
-            iter: self.buf.iter_mut(),
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
+        IterChannelsMut {
+            iter: self.buf.iter_channels_mut(),
             limit: self.limit,
         }
     }

--- a/audio-core/src/buf/macros.rs
+++ b/audio-core/src/buf/macros.rs
@@ -4,12 +4,12 @@ macro_rules! iterators {
         =>
         $self:ident . $fn:ident ($($arg:ident),* $(,)?)
     ) => {
-        pub struct Iter<I> {
+        pub struct IterChannels<I> {
             iter: I,
             $($field: $field_ty,)*
         }
 
-        impl<I> Iterator for Iter<I>
+        impl<I> Iterator for IterChannels<I>
         where
             I: Iterator,
             I::Item: Channel,
@@ -25,7 +25,7 @@ macro_rules! iterators {
             }
         }
 
-        impl<I> DoubleEndedIterator for Iter<I>
+        impl<I> DoubleEndedIterator for IterChannels<I>
         where
             I: DoubleEndedIterator,
             I::Item: Channel,
@@ -39,7 +39,7 @@ macro_rules! iterators {
             }
         }
 
-        impl<I> ExactSizeIterator for Iter<I>
+        impl<I> ExactSizeIterator for IterChannels<I>
         where
             I: ExactSizeIterator,
             I::Item: ChannelMut,
@@ -49,12 +49,12 @@ macro_rules! iterators {
             }
         }
 
-        pub struct IterMut<I> {
+        pub struct IterChannelsMut<I> {
             iter: I,
             $($field: $field_ty,)*
         }
 
-        impl<I> Iterator for IterMut<I>
+        impl<I> Iterator for IterChannelsMut<I>
         where
             I: Iterator,
             I::Item: ChannelMut,
@@ -70,7 +70,7 @@ macro_rules! iterators {
             }
         }
 
-        impl<I> DoubleEndedIterator for IterMut<I>
+        impl<I> DoubleEndedIterator for IterChannelsMut<I>
         where
             I: DoubleEndedIterator,
             I::Item: ChannelMut,
@@ -84,7 +84,7 @@ macro_rules! iterators {
             }
         }
 
-        impl<I> ExactSizeIterator for IterMut<I>
+        impl<I> ExactSizeIterator for IterChannelsMut<I>
         where
             I: ExactSizeIterator,
             I::Item: ChannelMut,

--- a/audio-core/src/buf/skip.rs
+++ b/audio-core/src/buf/skip.rs
@@ -41,7 +41,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<B::Iter<'this>>
+    type IterChannels<'this> = IterChannels<B::IterChannels<'this>>
     where
         Self: 'this;
 
@@ -54,13 +54,13 @@ where
         self.buf.channels()
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        Some(self.buf.get(channel)?.skip(self.n))
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        Some(self.buf.get_channel(channel)?.skip(self.n))
     }
 
-    fn iter(&self) -> Self::Iter<'_> {
-        Iter {
-            iter: self.buf.iter(),
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
+        IterChannels {
+            iter: self.buf.iter_channels(),
             n: self.n,
         }
     }
@@ -74,12 +74,12 @@ where
     where
         Self: 'a;
 
-    type IterMut<'a> = IterMut<B::IterMut<'a>>
+    type IterChannelsMut<'a> = IterChannelsMut<B::IterChannelsMut<'a>>
     where
         Self: 'a;
 
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.skip(self.n))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.skip(self.n))
     }
 
     fn copy_channel(&mut self, from: usize, to: usize)
@@ -89,9 +89,9 @@ where
         self.buf.copy_channel(from, to);
     }
 
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        IterMut {
-            iter: self.buf.iter_mut(),
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
+        IterChannelsMut {
+            iter: self.buf.iter_channels_mut(),
             n: self.n,
         }
     }

--- a/audio-core/src/buf/tail.rs
+++ b/audio-core/src/buf/tail.rs
@@ -25,7 +25,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<B::Iter<'this>>
+    type IterChannels<'this> = IterChannels<B::IterChannels<'this>>
     where
         Self: 'this;
 
@@ -38,13 +38,13 @@ where
         self.buf.channels()
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        Some(self.buf.get(channel)?.tail(self.n))
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        Some(self.buf.get_channel(channel)?.tail(self.n))
     }
 
-    fn iter(&self) -> Self::Iter<'_> {
-        Iter {
-            iter: self.buf.iter(),
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
+        IterChannels {
+            iter: self.buf.iter_channels(),
             n: self.n,
         }
     }
@@ -58,12 +58,12 @@ where
     where
         Self: 'a;
 
-    type IterMut<'a> = IterMut<B::IterMut<'a>>
+    type IterChannelsMut<'a> = IterChannelsMut<B::IterChannelsMut<'a>>
     where
         Self: 'a;
 
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.tail(self.n))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.tail(self.n))
     }
 
     fn copy_channel(&mut self, from: usize, to: usize)
@@ -73,9 +73,9 @@ where
         self.buf.copy_channel(from, to);
     }
 
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        IterMut {
-            iter: self.buf.iter_mut(),
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
+        IterChannelsMut {
+            iter: self.buf.iter_channels_mut(),
             n: self.n,
         }
     }

--- a/audio-core/src/buf_mut.rs
+++ b/audio-core/src/buf_mut.rs
@@ -8,7 +8,7 @@ pub trait BufMut: Buf {
         Self: 'this;
 
     /// A mutable iterator over available channels.
-    type IterMut<'this>: Iterator<Item = Self::ChannelMut<'this>>
+    type IterChannelsMut<'this>: Iterator<Item = Self::ChannelMut<'this>>
     where
         Self: 'this;
 
@@ -20,7 +20,7 @@ pub trait BufMut: Buf {
     /// use audio::{BufMut, ChannelMut};
     ///
     /// fn test(mut buf: impl BufMut<Sample = i32>) {
-    ///     for (n, mut chan) in buf.iter_mut().enumerate() {
+    ///     for (n, mut chan) in buf.iter_channels_mut().enumerate() {
     ///         for f in chan.iter_mut() {
     ///             *f += n as i32 + 1;
     ///         }
@@ -30,18 +30,18 @@ pub trait BufMut: Buf {
     /// let mut buf = audio::dynamic![[0; 4]; 2];
     /// test(&mut buf);
     /// assert_eq!(
-    ///     buf.iter().collect::<Vec<_>>(),
+    ///     buf.iter_channels().collect::<Vec<_>>(),
     ///     vec![[1, 1, 1, 1], [2, 2, 2, 2]],
     /// );
     ///
     /// let mut buf = audio::interleaved![[0; 4]; 2];
     /// test(&mut buf);
     /// assert_eq!(
-    ///     buf.iter().collect::<Vec<_>>(),
+    ///     buf.iter_channels().collect::<Vec<_>>(),
     ///     vec![[1, 1, 1, 1], [2, 2, 2, 2]],
     /// );
     /// ```
-    fn iter_mut(&mut self) -> Self::IterMut<'_>;
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_>;
 
     /// Return a mutable handler to the buffer associated with the channel.
     ///
@@ -51,7 +51,7 @@ pub trait BufMut: Buf {
     /// use audio::{BufMut, ChannelMut};
     ///
     /// fn test(mut buf: impl BufMut<Sample = i32>) {
-    ///     if let Some(mut chan) = buf.get_mut(1) {
+    ///     if let Some(mut chan) = buf.get_channel_mut(1) {
     ///         for f in chan.iter_mut() {
     ///             *f += 1;
     ///         }
@@ -61,11 +61,11 @@ pub trait BufMut: Buf {
     /// let mut buf = audio::dynamic![[0; 4]; 2];
     /// test(&mut buf);
     /// assert_eq!(
-    ///     buf.iter().collect::<Vec<_>>(),
+    ///     buf.iter_channels().collect::<Vec<_>>(),
     ///     vec![[0, 0, 0, 0], [1, 1, 1, 1]],
     /// );
     /// ```
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>>;
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>>;
 
     /// Copy one channel into another.
     ///
@@ -84,7 +84,7 @@ pub trait BufMut: Buf {
     ///
     /// let mut buf = audio::dynamic![[1, 2, 3, 4], [0, 0, 0, 0]];
     /// buf.copy_channel(0, 1);
-    /// assert_eq!(buf.get(1), buf.get(0));
+    /// assert_eq!(buf.get_channel(1), buf.get_channel(0));
     /// ```
     fn copy_channel(&mut self, from: usize, to: usize)
     where
@@ -104,7 +104,7 @@ pub trait BufMut: Buf {
     where
         Self::Sample: Copy,
     {
-        for mut channel in self.iter_mut() {
+        for mut channel in self.iter_channels_mut() {
             channel.fill(value);
         }
     }
@@ -118,13 +118,13 @@ where
     where
         Self: 'this;
 
-    type IterMut<'this> = B::IterMut<'this>
+    type IterChannelsMut<'this> = B::IterChannelsMut<'this>
     where
         Self: 'this;
 
     #[inline]
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        (**self).get_mut(channel)
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        (**self).get_channel_mut(channel)
     }
 
     #[inline]
@@ -136,7 +136,7 @@ where
     }
 
     #[inline]
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        (**self).iter_mut()
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
+        (**self).iter_channels_mut()
     }
 }

--- a/audio-core/src/channel.rs
+++ b/audio-core/src/channel.rs
@@ -1,11 +1,11 @@
-//! A channel buffer as created through [Buf::get][crate::Buf::get] or
-//! [BufMut::get_mut][crate::BufMut::get_mut].
+//! A channel buffer as created through [Buf::get_channel][crate::Buf::get_channel] or
+//! [BufMut::get_channel_mut][crate::BufMut::get_channel_mut].
 
 /// One channel of audio samples, usually one of several channels in a multichannel buffer
 ///
 /// This trait provides read-only access.
 ///
-/// See [Buf::get][crate::Buf::get].
+/// See [Buf::get_channel][crate::Buf::get_channel].
 pub trait Channel {
     /// The sample of a channel.
     type Sample: Copy;
@@ -31,7 +31,7 @@ pub trait Channel {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: impl Buf<Sample = f32>) {
-    ///     for chan in buf.iter() {
+    ///     for chan in buf.iter_channels() {
     ///         assert_eq!(chan.len(), 16);
     ///     }
     /// }
@@ -50,7 +50,7 @@ pub trait Channel {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: impl Buf<Sample = f32>) {
-    ///     for chan in buf.iter() {
+    ///     for chan in buf.iter_channels() {
     ///         assert!(!chan.is_empty());
     ///     }
     /// }
@@ -71,7 +71,7 @@ pub trait Channel {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: impl Buf<Sample = f32>) {
-    ///     for chan in buf.iter() {
+    ///     for chan in buf.iter_channels() {
     ///         assert_eq!(chan.get(15), Some(0.0));
     ///         assert_eq!(chan.get(16), None);
     ///     }
@@ -100,7 +100,7 @@ pub trait Channel {
     ///     }
     /// }
     ///
-    /// assert!(left.get(0).unwrap().iter().eq(right.get(0).unwrap().iter()));
+    /// assert!(left.get_channel(0).unwrap().iter().eq(right.get_channel(0).unwrap().iter()));
     ///
     /// assert_eq!(left.as_slice(), &[1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]);
     /// assert_eq!(&right[0], &[1.0, 1.0, 1.0, 1.0]);
@@ -118,7 +118,7 @@ pub trait Channel {
     /// use audio::{Buf, Channel};
     ///
     /// fn test(buf: &impl Buf<Sample = f32>, expected: Option<&[f32]>) {
-    ///     assert_eq!(buf.get(0).unwrap().try_as_linear(), expected);
+    ///     assert_eq!(buf.get_channel(0).unwrap().try_as_linear(), expected);
     /// }
     ///
     /// test(&audio::dynamic![[1.0; 16]; 2], Some(&[1.0; 16]));
@@ -136,7 +136,7 @@ pub trait Channel {
     ///
     /// let buf = audio::interleaved![[0; 4]; 2];
     ///
-    /// for chan in buf.iter() {
+    /// for chan in buf.iter_channels() {
     ///     assert_eq!(chan.skip(1).len(), 3);
     ///     assert_eq!(chan.skip(4).len(), 0);
     /// }
@@ -153,7 +153,7 @@ pub trait Channel {
     ///
     /// let mut to = audio::interleaved![[0.0f32; 4]; 2];
     ///
-    /// if let (Some(from), Some(to)) = (from.get(0), to.get_mut(0)) {
+    /// if let (Some(from), Some(to)) = (from.get_channel(0), to.get_channel_mut(0)) {
     ///     audio::channel::copy(from.skip(2), to);
     /// }
     ///
@@ -171,7 +171,7 @@ pub trait Channel {
     /// let from = audio::interleaved![[1.0f32; 4]; 2];
     /// let mut to = audio::interleaved![[0.0f32; 4]; 2];
     ///
-    /// if let (Some(from), Some(to)) = (from.get(0), to.get_mut(0)) {
+    /// if let (Some(from), Some(to)) = (from.get_channel(0), to.get_channel_mut(0)) {
     ///     audio::channel::copy(from, to.tail(2));
     /// }
     ///
@@ -189,7 +189,7 @@ pub trait Channel {
     /// let from = audio::interleaved![[1.0f32; 4]; 2];
     /// let mut to = audio::interleaved![[0.0f32; 4]; 2];
     ///
-    /// if let (Some(from), Some(to)) = (from.get(0), to.get_mut(0)) {
+    /// if let (Some(from), Some(to)) = (from.get_channel(0), to.get_channel_mut(0)) {
     ///     audio::channel::copy(from.limit(2), to);
     /// }
     ///

--- a/audio-core/src/channel.rs
+++ b/audio-core/src/channel.rs
@@ -1,7 +1,8 @@
 //! A channel buffer as created through [Buf::get_channel][crate::Buf::get_channel] or
 //! [BufMut::get_channel_mut][crate::BufMut::get_channel_mut].
 
-/// One channel of audio samples, usually one of several channels in a multichannel buffer
+/// One channel of audio samples, usually one of several channels in a
+/// multichannel buffer
 ///
 /// This trait provides read-only access.
 ///

--- a/audio-core/src/channel_mut.rs
+++ b/audio-core/src/channel_mut.rs
@@ -4,7 +4,7 @@ use crate::Channel;
 ///
 /// This trait provides read and write access.
 ///
-/// See [BufMut::get_mut][crate::BufMut::get_mut].
+/// See [BufMut::get_channel_mut][crate::BufMut::get_channel_mut].
 pub trait ChannelMut: Channel {
     /// A reborrowed mutable channel.
     type ChannelMut<'this>: ChannelMut<Sample = Self::Sample>
@@ -30,7 +30,7 @@ pub trait ChannelMut: Channel {
     /// use audio::{BufMut, ChannelMut};
     ///
     /// fn test(mut buf: impl BufMut<Sample = i16>) {
-    ///     for mut chan in buf.iter_mut() {
+    ///     for mut chan in buf.iter_channels_mut() {
     ///         if let Some(f) = chan.get_mut(2) {
     ///             *f = 1;
     ///         }
@@ -53,7 +53,7 @@ pub trait ChannelMut: Channel {
     /// use audio::{BufMut, Channel, ChannelMut};
     ///
     /// fn test(buf: &mut impl BufMut<Sample = f32>) {
-    ///     let is_linear = if let Some(linear) = buf.get_mut(0).unwrap().try_as_linear_mut() {
+    ///     let is_linear = if let Some(linear) = buf.get_channel_mut(0).unwrap().try_as_linear_mut() {
     ///         linear[2] = 1.0;
     ///         true
     ///     } else {
@@ -61,7 +61,7 @@ pub trait ChannelMut: Channel {
     ///     };
     ///
     ///     if is_linear {
-    ///         assert_eq!(buf.get(0).and_then(|c| c.get(2)), Some(1.0));
+    ///         assert_eq!(buf.get_channel(0).and_then(|c| c.get(2)), Some(1.0));
     ///     }
     /// }
     ///
@@ -79,11 +79,11 @@ pub trait ChannelMut: Channel {
     /// use audio::ChannelMut;
     ///
     /// let mut buf = audio::sequential![[0; 2]; 2];
-    /// for mut channel in buf.iter_mut() {
+    /// for mut channel in buf.iter_channels_mut() {
     ///     channel.fill(1);
     /// }
-    /// assert_eq!(buf.get(0).unwrap().as_ref(), &[1, 1]);
-    /// assert_eq!(buf.get(1).unwrap().as_ref(), &[1, 1]);
+    /// assert_eq!(buf.get_channel(0).unwrap().as_ref(), &[1, 1]);
+    /// assert_eq!(buf.get_channel(1).unwrap().as_ref(), &[1, 1]);
     /// ```
     fn fill(&mut self, value: Self::Sample) {
         for sample in self.iter_mut() {

--- a/audio-core/src/channel_mut.rs
+++ b/audio-core/src/channel_mut.rs
@@ -1,6 +1,7 @@
 use crate::Channel;
 
-/// One channel of audio samples, usually one of several channels in a multichannel buffer
+/// One channel of audio samples, usually one of several channels in a
+/// multichannel buffer
 ///
 /// This trait provides read and write access.
 ///

--- a/audio-core/src/interleaved_buf_mut.rs
+++ b/audio-core/src/interleaved_buf_mut.rs
@@ -18,12 +18,12 @@ pub trait InterleavedBufMut: InterleavedBuf {
     ///     buffer.as_interleaved_mut().copy_from_slice(&[1, 1, 2, 2, 3, 3, 4, 4]);
     ///
     ///     assert_eq! {
-    ///         buffer.get(0).unwrap().iter().collect::<Vec<_>>(),
+    ///         buffer.get_channel(0).unwrap().iter().collect::<Vec<_>>(),
     ///         &[1, 2, 3, 4],
     ///     };
     ///
     ///     assert_eq! {
-    ///         buffer.get(1).unwrap().iter().collect::<Vec<_>>(),
+    ///         buffer.get_channel(1).unwrap().iter().collect::<Vec<_>>(),
     ///         &[1, 2, 3, 4],
     ///     };
     ///
@@ -74,11 +74,11 @@ pub trait InterleavedBufMut: InterleavedBuf {
     /// test(&mut buf);
     ///
     /// assert_eq! {
-    ///     buf.get(0).unwrap().iter().collect::<Vec<_>>(),
+    ///     buf.get_channel(0).unwrap().iter().collect::<Vec<_>>(),
     ///     &[1, 1, 1, 1, 1, 1, 1, 1],
     /// };
     /// assert_eq! {
-    ///     buf.get(1).unwrap().iter().collect::<Vec<_>>(),
+    ///     buf.get_channel(1).unwrap().iter().collect::<Vec<_>>(),
     ///     &[1, 1, 1, 1, 1, 1, 1, 1],
     /// };
     /// ```
@@ -120,11 +120,11 @@ pub trait InterleavedBufMut: InterleavedBuf {
     /// test(&mut buf);
     ///
     /// assert_eq! {
-    ///     buf.get(0).unwrap().iter().collect::<Vec<_>>(),
+    ///     buf.get_channel(0).unwrap().iter().collect::<Vec<_>>(),
     ///     &[1, 1, 1, 1, 1, 1, 1, 1],
     /// };
     /// assert_eq! {
-    ///     buf.get(1).unwrap().iter().collect::<Vec<_>>(),
+    ///     buf.get_channel(1).unwrap().iter().collect::<Vec<_>>(),
     ///     &[1, 1, 1, 1, 1, 1, 1, 1],
     /// };
     /// ```

--- a/audio-core/src/resizable_buf.rs
+++ b/audio-core/src/resizable_buf.rs
@@ -26,7 +26,7 @@ pub trait ResizableBuf {
     /// use audio::{Buf, ExactSizeBuf, ResizableBuf};
     ///
     /// fn test(mut buffer: impl ResizableBuf) {
-    ///     buffer.resize(4);
+    ///     buffer.resize_frames(4);
     /// }
     ///
     /// let mut buf = audio::interleaved![[0; 0]; 2];
@@ -39,7 +39,7 @@ pub trait ResizableBuf {
     /// assert_eq!(buf.channels(), 2);
     /// assert_eq!(buf.frames(), 4);
     /// ```
-    fn resize(&mut self, frames: usize);
+    fn resize_frames(&mut self, frames: usize);
 
     /// Resize the buffer to match the given topology.
     ///
@@ -70,8 +70,8 @@ where
         (**self).try_reserve(capacity)
     }
 
-    fn resize(&mut self, frames: usize) {
-        (**self).resize(frames);
+    fn resize_frames(&mut self, frames: usize) {
+        (**self).resize_frames(frames);
     }
 
     fn resize_topology(&mut self, channels: usize, frames: usize) {

--- a/audio-core/src/uniform_buf.rs
+++ b/audio-core/src/uniform_buf.rs
@@ -9,7 +9,7 @@ pub trait UniformBuf: Buf {
         Self: 'this;
 
     /// A borrowing iterator over the channel.
-    type FramesIter<'this>: Iterator<Item = Self::Frame<'this>>
+    type IterFrames<'this>: Iterator<Item = Self::Frame<'this>>
     where
         Self: 'this;
 
@@ -76,5 +76,5 @@ pub trait UniformBuf: Buf {
     /// test(audio::interleaved![[1, 2, 3, 4], [5, 6, 7, 8]]);
     /// test(audio::wrap::sequential([1, 2, 3, 4, 5, 6, 7, 8], 2));
     /// ```
-    fn iter_frames(&self) -> Self::FramesIter<'_>;
+    fn iter_frames(&self) -> Self::IterFrames<'_>;
 }

--- a/audio/src/buf.rs
+++ b/audio/src/buf.rs
@@ -24,7 +24,7 @@ where
     O: BufMut<Sample = I::Sample>,
     I::Sample: Copy,
 {
-    for (from, to) in from.iter().zip(to.iter_mut()) {
+    for (from, to) in from.iter_channels().zip(to.iter_channels_mut()) {
         crate::channel::copy(from, to);
     }
 }
@@ -39,7 +39,7 @@ where
     O::Sample: Translate<I::Sample>,
     I::Sample: Copy,
 {
-    for (mut to, from) in to.iter_mut().zip(from.iter()) {
+    for (mut to, from) in to.iter_channels_mut().zip(from.iter_channels()) {
         for (t, f) in to.iter_mut().zip(from.iter()) {
             *t = O::Sample::translate(f);
         }

--- a/audio/src/buf/dynamic/iter.rs
+++ b/audio/src/buf/dynamic/iter.rs
@@ -37,13 +37,13 @@ macro_rules! forward {
 
 /// An iterator over the channels in the buffer.
 ///
-/// Created with [Dynamic::iter][crate::buf::Dynamic::iter].
-pub struct Iter<'a, T> {
+/// Created with [Dynamic::iter_channels][crate::buf::Dynamic::iter_channels].
+pub struct IterChannels<'a, T> {
     iter: slice::Iter<'a, RawSlice<T>>,
     len: usize,
 }
 
-impl<'a, T> Iter<'a, T> {
+impl<'a, T> IterChannels<'a, T> {
     /// Construct a new iterator.
     ///
     /// # Safety
@@ -58,13 +58,13 @@ impl<'a, T> Iter<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for Iter<'a, T> {
+impl<'a, T> Iterator for IterChannels<'a, T> {
     type Item = LinearChannel<'a, T>;
 
     forward!(as_linear_channel);
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+impl<'a, T> DoubleEndedIterator for IterChannels<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         let buf = self.iter.next_back()?;
@@ -78,7 +78,7 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+impl<'a, T> ExactSizeIterator for IterChannels<'a, T> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -86,13 +86,13 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {
 
 /// A mutable iterator over the channels in the buffer.
 ///
-/// Created with [Dynamic::iter_mut][crate::buf::Dynamic::iter_mut].
-pub struct IterMut<'a, T> {
+/// Created with [Dynamic::iter_channels_mut][crate::buf::Dynamic::iter_channels_mut].
+pub struct IterChannelsMut<'a, T> {
     iter: slice::IterMut<'a, RawSlice<T>>,
     len: usize,
 }
 
-impl<'a, T> IterMut<'a, T> {
+impl<'a, T> IterChannelsMut<'a, T> {
     /// Construct a new iterator.
     ///
     /// # Safety
@@ -107,13 +107,13 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for IterMut<'a, T> {
+impl<'a, T> Iterator for IterChannelsMut<'a, T> {
     type Item = LinearChannelMut<'a, T>;
 
     forward!(as_linear_channel_mut);
 }
 
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+impl<'a, T> DoubleEndedIterator for IterChannelsMut<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         let buf = self.iter.next_back()?;
@@ -127,7 +127,7 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T> {
+impl<'a, T> ExactSizeIterator for IterChannelsMut<'a, T> {
     fn len(&self) -> usize {
         self.iter.len()
     }

--- a/audio/src/buf/interleaved.rs
+++ b/audio/src/buf/interleaved.rs
@@ -1,7 +1,7 @@
 //! A dynamically sized, multi-channel interleaved audio buffer.
 
 mod iter;
-pub use self::iter::{Iter, IterMut};
+pub use self::iter::{IterChannels, IterChannelsMut};
 
 #[cfg(feature = "std")]
 mod buf;

--- a/audio/src/buf/interleaved/iter.rs
+++ b/audio/src/buf/interleaved/iter.rs
@@ -4,7 +4,7 @@ use core::ptr;
 use crate::channel::{InterleavedChannel, InterleavedChannelMut};
 
 /// An immutable iterator over an interleaved buffer.
-pub struct Iter<'a, T> {
+pub struct IterChannels<'a, T> {
     ptr: ptr::NonNull<T>,
     len: usize,
     channel: usize,
@@ -12,7 +12,7 @@ pub struct Iter<'a, T> {
     _marker: marker::PhantomData<&'a [T]>,
 }
 
-impl<'a, T> Iter<'a, T> {
+impl<'a, T> IterChannels<'a, T> {
     /// Construct a new unchecked iterator.
     ///
     /// # Safety
@@ -30,7 +30,7 @@ impl<'a, T> Iter<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for Iter<'a, T>
+impl<'a, T> Iterator for IterChannels<'a, T>
 where
     T: Copy,
 {
@@ -56,7 +56,7 @@ where
 }
 
 /// An mutable iterator over an interleaved buffer.
-pub struct IterMut<'a, T> {
+pub struct IterChannelsMut<'a, T> {
     ptr: ptr::NonNull<T>,
     len: usize,
     channel: usize,
@@ -64,7 +64,7 @@ pub struct IterMut<'a, T> {
     _marker: marker::PhantomData<&'a mut [T]>,
 }
 
-impl<'a, T> IterMut<'a, T> {
+impl<'a, T> IterChannelsMut<'a, T> {
     /// Construct a new unchecked iterator.
     ///
     /// # Safety
@@ -82,7 +82,7 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for IterMut<'a, T>
+impl<'a, T> Iterator for IterChannelsMut<'a, T>
 where
     T: Copy,
 {

--- a/audio/src/buf/sequential.rs
+++ b/audio/src/buf/sequential.rs
@@ -1,7 +1,7 @@
 //! A dynamically sized, multi-channel sequential audio buffer.
 
 mod iter;
-pub use self::iter::{Iter, IterMut};
+pub use self::iter::{IterChannels, IterChannelsMut};
 
 #[cfg(feature = "std")]
 mod buf;

--- a/audio/src/buf/sequential/iter.rs
+++ b/audio/src/buf/sequential/iter.rs
@@ -34,12 +34,12 @@ macro_rules! forward {
 
 /// An iterator over the channels in the buffer.
 ///
-/// Created with [Sequential::iter][super::Sequential::iter].
-pub struct Iter<'a, T> {
+/// Created with [Sequential::iter_channels][super::Sequential::iter_channels].
+pub struct IterChannels<'a, T> {
     iter: slice::ChunksExact<'a, T>,
 }
 
-impl<'a, T> Iter<'a, T> {
+impl<'a, T> IterChannels<'a, T> {
     #[inline]
     pub(crate) fn new(data: &'a [T], frames: usize) -> Self {
         Self {
@@ -48,13 +48,13 @@ impl<'a, T> Iter<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for Iter<'a, T> {
+impl<'a, T> Iterator for IterChannels<'a, T> {
     type Item = LinearChannel<'a, T>;
 
     forward!(LinearChannel);
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+impl<'a, T> DoubleEndedIterator for IterChannels<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         Some(LinearChannel::new(self.iter.next_back()?))
@@ -66,7 +66,7 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+impl<'a, T> ExactSizeIterator for IterChannels<'a, T> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -74,12 +74,12 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {
 
 /// A mutable iterator over the channels in the buffer.
 ///
-/// Created with [Sequential::iter_mut][super::Sequential::iter_mut].
-pub struct IterMut<'a, T> {
+/// Created with [Sequential::iter_channels_mut][super::Sequential::iter_channels_mut].
+pub struct IterChannelsMut<'a, T> {
     iter: slice::ChunksExactMut<'a, T>,
 }
 
-impl<'a, T> IterMut<'a, T> {
+impl<'a, T> IterChannelsMut<'a, T> {
     #[inline]
     pub(crate) fn new(data: &'a mut [T], frames: usize) -> Self {
         Self {
@@ -88,13 +88,13 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for IterMut<'a, T> {
+impl<'a, T> Iterator for IterChannelsMut<'a, T> {
     type Item = LinearChannelMut<'a, T>;
 
     forward!(LinearChannelMut);
 }
 
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+impl<'a, T> DoubleEndedIterator for IterChannelsMut<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         Some(LinearChannelMut::new(self.iter.next_back()?))
@@ -106,7 +106,7 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T> {
+impl<'a, T> ExactSizeIterator for IterChannelsMut<'a, T> {
     fn len(&self) -> usize {
         self.iter.len()
     }

--- a/audio/src/channel.rs
+++ b/audio/src/channel.rs
@@ -23,7 +23,7 @@ pub use self::interleaved::{InterleavedChannel, InterleavedChannelMut};
 /// let from = audio::interleaved![[1i16; 4]; 2];
 /// let mut to = audio::buf::Interleaved::<i16>::with_topology(2, 4);
 ///
-/// audio::channel::copy(from.limit(2).get(0).unwrap(), to.get_mut(0).unwrap());
+/// audio::channel::copy(from.limit(2).get_channel(0).unwrap(), to.get_mut(0).unwrap());
 /// assert_eq!(to.as_slice(), &[1, 0, 1, 0, 0, 0, 0, 0]);
 /// ```
 pub fn copy<I, O>(from: I, mut to: O)

--- a/audio/src/channel/interleaved.rs
+++ b/audio/src/channel/interleaved.rs
@@ -34,8 +34,10 @@ slice_comparisons!({'a, T}, InterleavedChannelMut<'a, T>, [T]);
 slice_comparisons!({'a, T}, InterleavedChannelMut<'a, T>, &[T]);
 slice_comparisons!(#[cfg(feature = "std")] {'a, T}, InterleavedChannelMut<'a, T>, Vec<T>);
 
-/// Read-only access to a single channel of audio within an interleaved, multichannel audio buffer.
-/// This struct does not own the audio data; it provides an API for accessing data owned by something else.
+/// Read-only access to a single channel of audio within an interleaved,
+/// multichannel audio buffer. This struct does not own the audio data; it
+/// provides an API for accessing data owned by something else.
+///
 /// See also [crate::buf::Interleaved].
 pub struct InterleavedChannel<'a, T> {
     /// The base pointer of the buffer.
@@ -92,8 +94,10 @@ impl<'a, T> InterleavedChannel<'a, T> {
     }
 }
 
-/// Read-write access to a single channel of audio within an interleaved, multichannel audio buffer.
-/// This struct does not own the audio data; it provides an API for accessing data owned by something else.
+/// Read-write access to a single channel of audio within an interleaved,
+/// multichannel audio buffer. This struct does not own the audio data; it
+/// provides an API for accessing data owned by something else.
+///
 /// See also [crate::buf::Interleaved].
 pub struct InterleavedChannelMut<'a, T> {
     /// The base pointer of the buffer.

--- a/audio/src/channel/linear.rs
+++ b/audio/src/channel/linear.rs
@@ -24,8 +24,10 @@ slice_comparisons!({'a, T}, LinearChannelMut<'a, T>, [T]);
 slice_comparisons!({'a, T}, LinearChannelMut<'a, T>, &[T]);
 slice_comparisons!(#[cfg(feature = "std")] {'a, T}, LinearChannelMut<'a, T>, Vec<T>);
 
-/// Read-only access to a single channel of audio within a linear, multichannel audio buffer.
-/// This struct does not own the audio data; it provides an API for accessing data owned by something else.
+/// Read-only access to a single channel of audio within a linear, multichannel
+/// audio buffer. This struct does not own the audio data; it provides an API
+/// for accessing data owned by something else.
+///
 /// See also [crate::buf::Sequential].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -159,8 +161,10 @@ where
     }
 }
 
-/// Read-write access to a single channel of audio within a linear, multichannel audio buffer.
-/// This struct does not own the audio data; it provides an API for accessing data owned by something else.
+/// Read-write access to a single channel of audio within a linear, multichannel
+/// audio buffer. This struct does not own the audio data; it provides an API
+/// for accessing data owned by something else.
+///
 /// See also [crate::buf::Sequential].
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LinearChannelMut<'a, T> {

--- a/audio/src/io/macros.rs
+++ b/audio/src/io/macros.rs
@@ -8,7 +8,7 @@ macro_rules! iter {
         where
             B: 'a + Buf,
         {
-            iter: B::Iter<'a>,
+            iter: B::IterChannels<'a>,
             $($field: $field_ty,)*
         }
 
@@ -36,7 +36,7 @@ macro_rules! iter_mut {
         where
             B: 'a + BufMut,
         {
-            iter: B::IterMut<'a>,
+            iter: B::IterChannelsMut<'a>,
             $($field: $field_ty,)*
         }
 

--- a/audio/src/io/macros.rs
+++ b/audio/src/io/macros.rs
@@ -18,6 +18,7 @@ macro_rules! iter {
         {
             type Item = B::Channel<'a>;
 
+            #[inline]
             fn next(&mut $self) -> Option<Self::Item> {
                 let channel = $self.iter.next()?;
                 Some(channel $(. $fn ($($self . $arg),*))*)
@@ -46,6 +47,7 @@ macro_rules! iter_mut {
         {
             type Item = B::ChannelMut<'a>;
 
+            #[inline]
             fn next(&mut $self) -> Option<Self::Item> {
                 let channel = $self.iter.next()?;
                 Some(channel $(. $fn ($($self . $arg),*))*)

--- a/audio/src/io/read.rs
+++ b/audio/src/io/read.rs
@@ -72,7 +72,8 @@ impl<B> Read<B> {
     /// assert!(!buf.has_remaining());
     /// assert_eq!(buf.remaining(), 0);
     /// ```
-    pub fn empty(buf: B) -> Self {
+    #[inline]
+    pub const fn empty(buf: B) -> Self {
         Self { buf, available: 0 }
     }
 
@@ -178,6 +179,7 @@ where
     B: Buf,
 {
     /// Construct an iterator over all available channels.
+    #[inline]
     pub fn iter(&self) -> Iter<B> {
         Iter {
             iter: self.buf.iter_channels(),
@@ -191,6 +193,7 @@ where
     B: BufMut,
 {
     /// Construct a mutable iterator over all available channels.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<B> {
         IterMut {
             iter: self.buf.iter_channels_mut(),
@@ -200,10 +203,12 @@ where
 }
 
 impl<B> ReadBuf for Read<B> {
+    #[inline]
     fn remaining(&self) -> usize {
         self.available
     }
 
+    #[inline]
     fn advance(&mut self, n: usize) {
         self.available = self.available.saturating_sub(n);
     }
@@ -213,6 +218,7 @@ impl<B> ExactSizeBuf for Read<B>
 where
     B: ExactSizeBuf,
 {
+    #[inline]
     fn frames(&self) -> usize {
         self.buf.frames().saturating_sub(self.available)
     }
@@ -232,18 +238,22 @@ where
     where
         Self: 'this;
 
+    #[inline]
     fn frames_hint(&self) -> Option<usize> {
         self.buf.frames_hint()
     }
 
+    #[inline]
     fn channels(&self) -> usize {
         self.buf.channels()
     }
 
+    #[inline]
     fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
         Some(self.buf.get_channel(channel)?.tail(self.available))
     }
 
+    #[inline]
     fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }

--- a/audio/src/io/read.rs
+++ b/audio/src/io/read.rs
@@ -180,7 +180,7 @@ where
     /// Construct an iterator over all available channels.
     pub fn iter(&self) -> Iter<B> {
         Iter {
-            iter: self.buf.iter(),
+            iter: self.buf.iter_channels(),
             available: self.available,
         }
     }
@@ -193,7 +193,7 @@ where
     /// Construct a mutable iterator over all available channels.
     pub fn iter_mut(&mut self) -> IterMut<B> {
         IterMut {
-            iter: self.buf.iter_mut(),
+            iter: self.buf.iter_channels_mut(),
             available: self.available,
         }
     }
@@ -228,7 +228,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<'this, B>
+    type IterChannels<'this> = Iter<'this, B>
     where
         Self: 'this;
 
@@ -240,11 +240,11 @@ where
         self.buf.channels()
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        Some(self.buf.get(channel)?.tail(self.available))
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        Some(self.buf.get_channel(channel)?.tail(self.available))
     }
 
-    fn iter(&self) -> Self::Iter<'_> {
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }
 }
@@ -257,13 +257,13 @@ where
     where
         Self: 'a;
 
-    type IterMut<'a> = IterMut<'a, B>
+    type IterChannelsMut<'a> = IterMut<'a, B>
     where
         Self: 'a;
 
     #[inline]
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.tail(self.available))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.tail(self.available))
     }
 
     #[inline]
@@ -275,7 +275,7 @@ where
     }
 
     #[inline]
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
         (*self).iter_mut()
     }
 }

--- a/audio/src/io/read_write.rs
+++ b/audio/src/io/read_write.rs
@@ -278,7 +278,7 @@ where
         let len = self.remaining();
 
         Iter {
-            iter: self.buf.iter(),
+            iter: self.buf.iter_channels(),
             len,
             read: self.read,
         }
@@ -292,7 +292,7 @@ where
     /// Construct a mutable iterator over all available channels.
     pub fn iter_mut(&mut self) -> IterMut<B> {
         IterMut {
-            iter: self.buf.iter_mut(),
+            iter: self.buf.iter_channels_mut(),
             written: self.written,
         }
     }
@@ -308,7 +308,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<'this, B>
+    type IterChannels<'this> = Iter<'this, B>
     where
         Self: 'this;
 
@@ -323,14 +323,14 @@ where
     }
 
     #[inline]
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        let channel = self.buf.get(channel)?;
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        let channel = self.buf.get_channel(channel)?;
         let len = self.remaining();
         Some(channel.skip(self.read).limit(len))
     }
 
     #[inline]
-    fn iter(&self) -> Self::Iter<'_> {
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }
 }
@@ -343,13 +343,13 @@ where
     where
         Self: 'this;
 
-    type IterMut<'this> = IterMut<'this, B>
+    type IterChannelsMut<'this> = IterMut<'this, B>
     where
         Self: 'this;
 
     #[inline]
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.skip(self.written))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.skip(self.written))
     }
 
     #[inline]
@@ -361,7 +361,7 @@ where
     }
 
     #[inline]
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
         (*self).iter_mut()
     }
 }

--- a/audio/src/io/write.rs
+++ b/audio/src/io/write.rs
@@ -182,7 +182,7 @@ where
     /// Construct an iterator over all available channels.
     pub fn iter(&self) -> Iter<B> {
         Iter {
-            iter: self.buf.iter(),
+            iter: self.buf.iter_channels(),
             available: self.available,
         }
     }
@@ -195,7 +195,7 @@ where
     /// Construct a mutable iterator over all available channels.
     pub fn iter_mut(&mut self) -> IterMut<B> {
         IterMut {
-            iter: self.buf.iter_mut(),
+            iter: self.buf.iter_channels_mut(),
             available: self.available,
         }
     }
@@ -233,7 +233,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<'this, B>
+    type IterChannels<'this> = Iter<'this, B>
     where
         Self: 'this;
 
@@ -245,11 +245,11 @@ where
         self.buf.channels()
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
-        Some(self.buf.get(channel)?.tail(self.available))
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
+        Some(self.buf.get_channel(channel)?.tail(self.available))
     }
 
-    fn iter(&self) -> Self::Iter<'_> {
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }
 }
@@ -262,13 +262,13 @@ where
     where
         Self: 'a;
 
-    type IterMut<'a> = IterMut<'a, B>
+    type IterChannelsMut<'a> = IterMut<'a, B>
     where
         Self: 'a;
 
     #[inline]
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
-        Some(self.buf.get_mut(channel)?.tail(self.available))
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+        Some(self.buf.get_channel_mut(channel)?.tail(self.available))
     }
 
     #[inline]
@@ -280,7 +280,7 @@ where
     }
 
     #[inline]
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
         (*self).iter_mut()
     }
 }

--- a/audio/src/io/write.rs
+++ b/audio/src/io/write.rs
@@ -49,6 +49,7 @@ impl<B> Write<B> {
     /// assert!(buf.has_remaining_mut());
     /// assert_eq!(buf.remaining_mut(), 4);
     /// ```
+    #[inline]
     pub fn new(buf: B) -> Self
     where
         B: ExactSizeBuf,
@@ -76,7 +77,8 @@ impl<B> Write<B> {
     /// assert!(!buf.has_remaining_mut());
     /// assert_eq!(buf.remaining_mut(), 0);
     /// ```
-    pub fn empty(buf: B) -> Self {
+    #[inline]
+    pub const fn empty(buf: B) -> Self {
         Self { buf, available: 0 }
     }
 
@@ -94,6 +96,7 @@ impl<B> Write<B> {
     ///
     /// assert_eq!(buf.as_ref().channels(), 4);
     /// ```
+    #[inline]
     pub fn as_ref(&self) -> &B {
         &self.buf
     }
@@ -115,6 +118,7 @@ impl<B> Write<B> {
     ///
     /// assert_eq!(buf.channels(), 2);
     /// ```
+    #[inline]
     pub fn as_mut(&mut self) -> &mut B {
         &mut self.buf
     }
@@ -136,6 +140,7 @@ impl<B> Write<B> {
     ///
     /// assert_eq!(buf.channels(), 4);
     /// ```
+    #[inline]
     pub fn into_inner(self) -> B {
         self.buf
     }
@@ -180,6 +185,7 @@ where
     B: Buf,
 {
     /// Construct an iterator over all available channels.
+    #[inline]
     pub fn iter(&self) -> Iter<B> {
         Iter {
             iter: self.buf.iter_channels(),
@@ -193,6 +199,7 @@ where
     B: BufMut,
 {
     /// Construct a mutable iterator over all available channels.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<B> {
         IterMut {
             iter: self.buf.iter_channels_mut(),
@@ -218,6 +225,7 @@ impl<B> ExactSizeBuf for Write<B>
 where
     B: ExactSizeBuf,
 {
+    #[inline]
     fn frames(&self) -> usize {
         self.buf.frames()
     }
@@ -237,18 +245,22 @@ where
     where
         Self: 'this;
 
+    #[inline]
     fn frames_hint(&self) -> Option<usize> {
         self.buf.frames_hint()
     }
 
+    #[inline]
     fn channels(&self) -> usize {
         self.buf.channels()
     }
 
+    #[inline]
     fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
         Some(self.buf.get_channel(channel)?.tail(self.available))
     }
 
+    #[inline]
     fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -81,7 +81,7 @@
 //! let mut buf = audio::buf::Dynamic::<f32>::new();
 //!
 //! buf.resize_channels(2);
-//! buf.resize(2048);
+//! buf.resize_frames(2048);
 //!
 //! /// Fill both channels with random noise.
 //! let mut rng = rand::thread_rng();

--- a/audio/src/macros.rs
+++ b/audio/src/macros.rs
@@ -135,8 +135,8 @@ macro_rules! sequential {
 ///
 /// let mut expected = vec![0; 64];
 ///
-/// assert!(buf.get(0).unwrap().iter().eq(expected.iter().copied()));
-/// assert!(buf.get(1).unwrap().iter().eq(expected.iter().copied()));
+/// assert!(buf.get_channel(0).unwrap().iter().eq(expected.iter().copied()));
+/// assert!(buf.get_channel(1).unwrap().iter().eq(expected.iter().copied()));
 /// ```
 ///
 /// Calling the macro with a template channel.

--- a/audio/src/tests/copy_channel.rs
+++ b/audio/src/tests/copy_channel.rs
@@ -11,7 +11,7 @@ fn test_copy_channels_dynamic() {
     let mut buf: buf::Dynamic<i16> = crate::dynamic![[1, 2, 3, 4], [0, 0, 0, 0]];
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1), buf.get(0));
+    assert_eq!(buf.get_channel(1), buf.get_channel(0));
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn test_copy_channels_sequential() {
     let mut buf: buf::Sequential<i16> = crate::sequential![[1, 2, 3, 4], [0, 0, 0, 0]];
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1), buf.get(0));
+    assert_eq!(buf.get_channel(1), buf.get_channel(0));
     assert_eq!(buf.as_slice(), &[1, 2, 3, 4, 1, 2, 3, 4]);
 }
 
@@ -30,7 +30,7 @@ fn test_copy_channels_wrap_sequential() {
     let mut buf: wrap::Sequential<&mut [i16]> = wrap::sequential(data, 2);
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1), buf.get(0));
+    assert_eq!(buf.get_channel(1), buf.get_channel(0));
     assert_eq!(data, &[1, 2, 3, 4, 1, 2, 3, 4]);
 }
 
@@ -39,7 +39,7 @@ fn test_copy_channels_interleaved() {
     let mut buf: buf::Interleaved<i16> = crate::interleaved![[1, 2, 3, 4], [0, 0, 0, 0]];
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1), buf.get(0));
+    assert_eq!(buf.get_channel(1), buf.get_channel(0));
     assert_eq!(buf.as_slice(), &[1, 1, 2, 2, 3, 3, 4, 4]);
 }
 
@@ -49,7 +49,7 @@ fn test_copy_channels_wrap_interleaved() {
     let mut buf: wrap::Interleaved<&mut [i16]> = wrap::interleaved(&mut data[..], 2);
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1), buf.get(0));
+    assert_eq!(buf.get_channel(1), buf.get_channel(0));
     assert_eq!(&data[..], &[1, 1, 2, 2, 3, 3, 4, 4]);
 }
 
@@ -58,5 +58,5 @@ fn test_copy_channels_vec_of_vecs() {
     let mut buf = crate::wrap::dynamic(vec![vec![1, 2, 3, 4], vec![0, 0]]);
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get(1).unwrap(), buf.get(0).unwrap().limit(2));
+    assert_eq!(buf.get_channel(1).unwrap(), buf.get_channel(0).unwrap().limit(2));
 }

--- a/audio/src/tests/copy_channel.rs
+++ b/audio/src/tests/copy_channel.rs
@@ -58,5 +58,8 @@ fn test_copy_channels_vec_of_vecs() {
     let mut buf = crate::wrap::dynamic(vec![vec![1, 2, 3, 4], vec![0, 0]]);
     buf.copy_channel(0, 1);
 
-    assert_eq!(buf.get_channel(1).unwrap(), buf.get_channel(0).unwrap().limit(2));
+    assert_eq!(
+        buf.get_channel(1).unwrap(),
+        buf.get_channel(0).unwrap().limit(2)
+    );
 }

--- a/audio/src/tests/dynamic.rs
+++ b/audio/src/tests/dynamic.rs
@@ -7,31 +7,31 @@ fn test_channels_then_resize() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(1024);
+    buf.resize_frames(1024);
 
     let expected = vec![0.0; 1024];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
 fn test_resize_then_channels() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
-    buf.resize(1024);
+    buf.resize_frames(1024);
     buf.resize_channels(4);
 
     let expected = vec![0.0; 1024];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -40,11 +40,11 @@ fn test_empty_channels() {
 
     buf.resize_channels(4);
 
-    assert!(buf.get(0).is_some());
-    assert!(buf.get(1).is_some());
-    assert!(buf.get(2).is_some());
-    assert!(buf.get(3).is_some());
-    assert!(buf.get(4).is_none());
+    assert!(buf.get_channel(0).is_some());
+    assert!(buf.get_channel(1).is_some());
+    assert!(buf.get_channel(2).is_some());
+    assert!(buf.get_channel(3).is_some());
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn test_empty() {
     let buf = crate::buf::Dynamic::<f32>::new();
 
     assert_eq!(buf.frames(), 0);
-    assert!(buf.get(0).is_none());
+    assert!(buf.get_channel(0).is_none());
 }
 
 #[test]
@@ -60,15 +60,15 @@ fn test_multiple_resizes() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(1024);
+    buf.resize_frames(1024);
 
     let expected = vec![0.0; 1024];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -76,23 +76,23 @@ fn test_multiple_channel_resizes() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(1024);
+    buf.resize_frames(1024);
 
     let expected = vec![0.0f32; 1024];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 
     buf.resize_channels(2);
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert!(buf.get(2).is_none());
-    assert!(buf.get(3).is_none());
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert!(buf.get_channel(2).is_none());
+    assert!(buf.get_channel(3).is_none());
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_drop_empty() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
     assert_eq!(buf.frames(), 0);
-    buf.resize(1024);
+    buf.resize_frames(1024);
     assert_eq!(buf.frames(), 1024);
 }
 
@@ -108,7 +108,7 @@ fn test_drop_empty() {
 fn test_into_vecs() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
     buf.resize_channels(4);
-    buf.resize(512);
+    buf.resize_frames(512);
 
     let expected = vec![0.0; 512];
 
@@ -127,7 +127,7 @@ fn test_enabled_mut() {
     let mut buf = crate::buf::Dynamic::<f32>::with_topology(4, 1024);
     let mask: bittle::FixedSet<u128> = bittle::fixed_set![0, 2, 3];
 
-    for mut chan in mask.join(buf.iter_mut()) {
+    for mut chan in mask.join(buf.iter_channels_mut()) {
         for b in chan.iter_mut() {
             *b = 1.0;
         }
@@ -148,10 +148,10 @@ fn test_stale_allocation() {
     assert_eq!(buf[1][128], 0.0);
     buf[1][128] = 42.0;
 
-    buf.resize(64);
+    buf.resize_frames(64);
     assert!(buf[1].get(128).is_none());
 
-    buf.resize(256);
+    buf.resize_frames(256);
     assert_eq!(buf[1][128], 42.0);
 }
 
@@ -167,7 +167,7 @@ fn test_get_mut() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
     buf.resize_channels(2);
-    buf.resize(256);
+    buf.resize_frames(256);
 
     let mut rng = rand::thread_rng();
 
@@ -184,7 +184,7 @@ fn test_get_mut() {
 fn test_get_or_default() {
     let mut buf = crate::buf::Dynamic::<f32>::new();
 
-    buf.resize(256);
+    buf.resize_frames(256);
 
     let expected = vec![0f32; 256];
 
@@ -198,6 +198,6 @@ fn test_get_or_default() {
 fn test_resize_topology() {
     let mut buf = crate::buf::Dynamic::<f64>::with_topology(1, 1024);
 
-    buf.resize(20480);
+    buf.resize_frames(20480);
     buf.resize_channels(1);
 }

--- a/audio/src/tests/interleaved.rs
+++ b/audio/src/tests/interleaved.rs
@@ -32,7 +32,7 @@ fn test_init() {
 fn test_complicated() {
     let mut buf = crate::buf::Interleaved::<f32>::with_topology(2, 4);
 
-    let mut it = buf.iter_mut();
+    let mut it = buf.iter_channels_mut();
 
     let mut left_chan = it.next().unwrap();
     let mut right_chan = it.next().unwrap();
@@ -55,7 +55,7 @@ fn test_complicated() {
 fn test_iter() {
     let mut buf = crate::buf::Interleaved::<f32>::with_topology(2, 4);
 
-    let mut it = buf.iter_mut();
+    let mut it = buf.iter_channels_mut();
 
     for (c, f) in it.next().unwrap().iter_mut().zip(&[1.0, 2.0, 3.0, 4.0]) {
         *c = *f;
@@ -65,7 +65,7 @@ fn test_iter() {
         *c = *f;
     }
 
-    let channels = buf.iter().collect::<Vec<_>>();
+    let channels = buf.iter_channels().collect::<Vec<_>>();
     let left = channels[0].iter().collect::<Vec<_>>();
     let right = channels[1].iter().collect::<Vec<_>>();
     let left2 = channels[0].iter().collect::<Vec<_>>();
@@ -81,7 +81,7 @@ fn test_iter() {
 fn test_iter_mut() {
     let mut buf = crate::buf::Interleaved::<f32>::with_topology(2, 4);
 
-    let mut it = buf.iter_mut();
+    let mut it = buf.iter_channels_mut();
 
     for (c, f) in it.next().unwrap().iter_mut().zip(&[1.0, 2.0, 3.0, 4.0]) {
         *c = *f;
@@ -91,7 +91,7 @@ fn test_iter_mut() {
         *c = *f;
     }
 
-    let mut it = buf.iter_mut();
+    let mut it = buf.iter_channels_mut();
 
     let mut left = it.next().unwrap();
     let mut right = it.next().unwrap();
@@ -111,7 +111,7 @@ fn test_resize() {
     assert_eq!(buf.frames(), 0);
 
     buf.resize_channels(4);
-    buf.resize(256);
+    buf.resize_frames(256);
 
     assert_eq!(buf.channels(), 4);
     assert_eq!(buf.frames(), 256);
@@ -124,16 +124,16 @@ fn test_resize() {
         assert_eq!(chan.get(127), Some(42.0));
     }
 
-    buf.resize(128);
+    buf.resize_frames(128);
     assert_eq!(buf.sample(1, 127), Some(42.0));
 
-    buf.resize(256);
+    buf.resize_frames(256);
     assert_eq!(buf.sample(1, 127), Some(42.0));
 
     buf.resize_channels(2);
     assert_eq!(buf.sample(1, 127), Some(42.0));
 
-    buf.resize(64);
+    buf.resize_frames(64);
     assert_eq!(buf.sample(1, 127), None);
 }
 
@@ -167,11 +167,11 @@ fn test_as_interleaved_mut_ptr() {
     test(&mut buf);
 
     assert_eq! {
-        buf.get(0).unwrap().iter().collect::<Vec<_>>(),
+        buf.get_channel(0).unwrap().iter().collect::<Vec<_>>(),
         &[1, 1, 1, 1, 1, 1, 1, 1],
     };
     assert_eq! {
-        buf.get(1).unwrap().iter().collect::<Vec<_>>(),
+        buf.get_channel(1).unwrap().iter().collect::<Vec<_>>(),
         &[1, 1, 1, 1, 1, 1, 1, 1],
     };
 }

--- a/audio/src/tests/sequential.rs
+++ b/audio/src/tests/sequential.rs
@@ -7,31 +7,31 @@ fn test_channels_then_resize() {
     let mut buf = crate::buf::Sequential::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(128);
+    buf.resize_frames(128);
 
     let expected = vec![0.0; 128];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert_eq!(None, buf.get(4));
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert_eq!(None, buf.get_channel(4));
 }
 
 #[test]
 fn test_resize_then_channels() {
     let mut buf = crate::buf::Sequential::<f32>::new();
 
-    buf.resize(128);
+    buf.resize_frames(128);
     buf.resize_channels(4);
 
     let expected = vec![0.0; 128];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -40,11 +40,11 @@ fn test_empty_channels() {
 
     buf.resize_channels(4);
 
-    assert!(buf.get(0).is_some());
-    assert!(buf.get(1).is_some());
-    assert!(buf.get(2).is_some());
-    assert!(buf.get(3).is_some());
-    assert!(buf.get(4).is_none());
+    assert!(buf.get_channel(0).is_some());
+    assert!(buf.get_channel(1).is_some());
+    assert!(buf.get_channel(2).is_some());
+    assert!(buf.get_channel(3).is_some());
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn test_empty() {
     let buf = crate::buf::Sequential::<f32>::new();
 
     assert_eq!(buf.frames(), 0);
-    assert!(buf.get(0).is_none());
+    assert!(buf.get_channel(0).is_none());
 }
 
 #[test]
@@ -60,15 +60,15 @@ fn test_multiple_resizes() {
     let mut buf = crate::buf::Sequential::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(128);
+    buf.resize_frames(128);
 
     let expected = vec![0.0; 128];
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 }
 
 #[test]
@@ -77,12 +77,12 @@ fn test_unaligned_resize() {
     buf[0].copy_from_slice(&[1.0, 2.0, 3.0, 4.0]);
     buf[1].copy_from_slice(&[2.0, 3.0, 4.0, 5.0]);
 
-    buf.resize(3);
+    buf.resize_frames(3);
 
     assert_eq!(&buf[0], &[1.0, 2.0, 3.0]);
     assert_eq!(&buf[1], &[2.0, 3.0, 4.0]);
 
-    buf.resize(4);
+    buf.resize_frames(4);
 
     assert_eq!(&buf[0], &[1.0, 2.0, 3.0, 2.0]); // <- 2.0 is stale data.
     assert_eq!(&buf[1], &[2.0, 3.0, 4.0, 5.0]); // <- 5.0 is stale data.
@@ -93,37 +93,37 @@ fn test_multiple_channel_resizes() {
     let mut buf = crate::buf::Sequential::<f32>::new();
 
     buf.resize_channels(4);
-    buf.resize(128);
+    buf.resize_frames(128);
 
     let expected = (0..128).map(|v| v as f32).collect::<Vec<_>>();
 
-    for mut chan in buf.iter_mut() {
+    for mut chan in buf.iter_channels_mut() {
         for (s, v) in chan.iter_mut().zip(&expected) {
             *s = *v;
         }
     }
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert_eq!(buf.get(2).unwrap(), &expected[..]);
-    assert_eq!(buf.get(3).unwrap(), &expected[..]);
-    assert!(buf.get(4).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(2).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(3).unwrap(), &expected[..]);
+    assert!(buf.get_channel(4).is_none());
 
     buf.resize_channels(2);
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert!(buf.get(2).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert!(buf.get_channel(2).is_none());
 
     // shrink
-    buf.resize(64);
+    buf.resize_frames(64);
 
-    assert_eq!(buf.get(0).unwrap(), &expected[..64]);
-    assert_eq!(buf.get(1).unwrap(), &expected[..64]);
-    assert!(buf.get(2).is_none());
+    assert_eq!(buf.get_channel(0).unwrap(), &expected[..64]);
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..64]);
+    assert!(buf.get_channel(2).is_none());
 
     // increase - this causes some weirdness.
-    buf.resize(128);
+    buf.resize_frames(128);
 
     let first_overlapping = expected[..64]
         .iter()
@@ -131,11 +131,11 @@ fn test_multiple_channel_resizes() {
         .copied()
         .collect::<Vec<_>>();
 
-    assert_eq!(buf.get(0).unwrap(), &first_overlapping[..]);
+    assert_eq!(buf.get_channel(0).unwrap(), &first_overlapping[..]);
     // Note: second channel matches perfectly up with an old channel that was
     // masked out.
-    assert_eq!(buf.get(1).unwrap(), &expected[..]);
-    assert!(buf.get(2).is_none());
+    assert_eq!(buf.get_channel(1).unwrap(), &expected[..]);
+    assert!(buf.get_channel(2).is_none());
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn test_drop_empty() {
     let mut buf = crate::buf::Sequential::<f32>::new();
 
     assert_eq!(buf.frames(), 0);
-    buf.resize(128);
+    buf.resize_frames(128);
     assert_eq!(buf.frames(), 128);
 }
 
@@ -153,10 +153,10 @@ fn test_stale_allocation() {
     assert_eq!(buf[1][128], 0.0);
     buf[1][128] = 42.0;
 
-    buf.resize(64);
+    buf.resize_frames(64);
     assert!(buf[1].get(128).is_none());
 
-    buf.resize(256);
+    buf.resize_frames(256);
     assert_eq!(buf[1][128], 0.0);
 }
 

--- a/audio/src/wrap/dynamic.rs
+++ b/audio/src/wrap/dynamic.rs
@@ -66,7 +66,7 @@ macro_rules! impl_buf {
             where
                 Self: 'this;
 
-            type Iter<'this> = Iter<'this, T>
+            type IterChannels<'this> = IterChannels<'this, T>
             where
                 Self: 'this;
 
@@ -81,13 +81,13 @@ macro_rules! impl_buf {
             }
 
             #[inline]
-            fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
+            fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
                 Some(LinearChannel::new(self.value.get(channel)?))
             }
 
             #[inline]
-            fn iter(&self) -> Self::Iter<'_> {
-                Iter {
+            fn iter_channels(&self) -> Self::IterChannels<'_> {
+                IterChannels {
                     iter: self.value[..].iter(),
                 }
             }
@@ -114,12 +114,12 @@ macro_rules! impl_buf_mut {
             where
                 Self: 'this;
 
-            type IterMut<'this> = IterMut<'this, T>
+            type IterChannelsMut<'this> = IterChannelsMut<'this, T>
             where
                 Self: 'this;
 
             #[inline]
-            fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+            fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
                 Some(LinearChannelMut::new(self.value.get_mut(channel)?.as_mut()))
             }
 
@@ -151,8 +151,8 @@ macro_rules! impl_buf_mut {
             }
 
             #[inline]
-            fn iter_mut(&mut self) -> Self::IterMut<'_> {
-                IterMut {
+            fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
+                IterChannelsMut {
                     iter: self.value[..].iter_mut(),
                 }
             }
@@ -176,7 +176,7 @@ where
     }
 
     #[inline]
-    fn resize(&mut self, frames: usize) {
+    fn resize_frames(&mut self, frames: usize) {
         for buf in self.value.iter_mut() {
             buf.resize(frames, T::ZERO);
         }
@@ -194,11 +194,11 @@ where
 }
 
 /// An iterator over a linear channel slice buffer.
-pub struct Iter<'a, T> {
+pub struct IterChannels<'a, T> {
     iter: std::slice::Iter<'a, Vec<T>>,
 }
 
-impl<'a, T> Iterator for Iter<'a, T>
+impl<'a, T> Iterator for IterChannels<'a, T>
 where
     T: Copy,
 {
@@ -215,7 +215,7 @@ where
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T>
+impl<'a, T> DoubleEndedIterator for IterChannels<'a, T>
 where
     T: Copy,
 {
@@ -230,7 +230,7 @@ where
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T>
+impl<'a, T> ExactSizeIterator for IterChannels<'a, T>
 where
     T: Copy,
 {
@@ -241,11 +241,11 @@ where
 }
 
 /// A mutable iterator over a linear channel slice buffer.
-pub struct IterMut<'a, T> {
+pub struct IterChannelsMut<'a, T> {
     iter: std::slice::IterMut<'a, Vec<T>>,
 }
 
-impl<'a, T> Iterator for IterMut<'a, T>
+impl<'a, T> Iterator for IterChannelsMut<'a, T>
 where
     T: Copy,
 {
@@ -262,7 +262,7 @@ where
     }
 }
 
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T>
+impl<'a, T> DoubleEndedIterator for IterChannelsMut<'a, T>
 where
     T: Copy,
 {
@@ -277,7 +277,7 @@ where
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T>
+impl<'a, T> ExactSizeIterator for IterChannelsMut<'a, T>
 where
     T: Copy,
 {

--- a/audio/src/wrap/interleaved.rs
+++ b/audio/src/wrap/interleaved.rs
@@ -87,7 +87,9 @@ where
     /// Construct an iterator over the interleaved wrapper.
     #[inline]
     pub fn iter_mut(&mut self) -> IterChannelsMut<'_, T::Item> {
-        unsafe { IterChannelsMut::new_unchecked(self.value.as_mut_ptr(), self.value.len(), self.channels) }
+        unsafe {
+            IterChannelsMut::new_unchecked(self.value.as_mut_ptr(), self.value.len(), self.channels)
+        }
     }
 }
 

--- a/audio/src/wrap/sequential.rs
+++ b/audio/src/wrap/sequential.rs
@@ -1,6 +1,6 @@
 use audio_core::{Buf, BufMut, ExactSizeBuf, UniformBuf};
 
-use crate::buf::sequential::{Iter, IterMut};
+use crate::buf::sequential::{IterChannels, IterChannelsMut};
 use crate::channel::{LinearChannel, LinearChannelMut};
 use crate::frame::{RawSequential, SequentialFrame, SequentialFramesIter};
 use crate::slice::{Slice, SliceMut};
@@ -60,8 +60,8 @@ where
     /// assert_eq!(it.next().unwrap(), [3, 4]);
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<'_, T::Item> {
-        Iter::new(self.value.as_ref(), self.frames)
+    pub fn iter(&self) -> IterChannels<'_, T::Item> {
+        IterChannels::new(self.value.as_ref(), self.frames)
     }
 
     /// Access the raw sequential buffer.
@@ -81,8 +81,8 @@ where
 {
     /// Construct an iterator over all sequential channels.
     #[inline]
-    pub fn iter_mut(&mut self) -> IterMut<'_, T::Item> {
-        IterMut::new(self.value.as_mut(), self.frames)
+    pub fn iter_mut(&mut self) -> IterChannelsMut<'_, T::Item> {
+        IterChannelsMut::new(self.value.as_mut(), self.frames)
     }
 }
 
@@ -96,7 +96,7 @@ where
     where
         Self: 'this;
 
-    type Iter<'this> = Iter<'this, Self::Sample>
+    type IterChannels<'this> = IterChannels<'this, Self::Sample>
     where
         Self: 'this;
 
@@ -110,7 +110,7 @@ where
         self.channels
     }
 
-    fn get(&self, channel: usize) -> Option<Self::Channel<'_>> {
+    fn get_channel(&self, channel: usize) -> Option<Self::Channel<'_>> {
         let value = self
             .value
             .as_ref()
@@ -121,7 +121,7 @@ where
     }
 
     #[inline]
-    fn iter(&self) -> Self::Iter<'_> {
+    fn iter_channels(&self) -> Self::IterChannels<'_> {
         (*self).iter()
     }
 }
@@ -134,7 +134,7 @@ where
     where
         Self: 'this;
 
-    type FramesIter<'this> = SequentialFramesIter<'this, T::Item>
+    type IterFrames<'this> = SequentialFramesIter<'this, T::Item>
     where
         Self: 'this;
 
@@ -148,7 +148,7 @@ where
     }
 
     #[inline]
-    fn iter_frames(&self) -> Self::FramesIter<'_> {
+    fn iter_frames(&self) -> Self::IterFrames<'_> {
         SequentialFramesIter::new(0, self.as_raw())
     }
 }
@@ -171,11 +171,11 @@ where
     where
         Self: 'a;
 
-    type IterMut<'a> = IterMut<'a, Self::Sample>
+    type IterChannelsMut<'a> = IterChannelsMut<'a, Self::Sample>
     where
         Self: 'a;
 
-    fn get_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
+    fn get_channel_mut(&mut self, channel: usize) -> Option<Self::ChannelMut<'_>> {
         let value = self
             .value
             .as_mut()
@@ -201,7 +201,7 @@ where
         }
     }
 
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+    fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
         (*self).iter_mut()
     }
 }

--- a/audio/src/wrap/sequential.rs
+++ b/audio/src/wrap/sequential.rs
@@ -201,6 +201,7 @@ where
         }
     }
 
+    #[inline]
     fn iter_channels_mut(&mut self) -> Self::IterChannelsMut<'_> {
         (*self).iter_mut()
     }


### PR DESCRIPTION
This renames Buf::get -> Buf::get_channel & Buf::iter -> Buf::iter_channels and likewise for BufMut. This emphasizes that these functions refer to channels rather than frames without needing to read the documentation.