### PR TITLE
remove [patch] section from root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,3 @@ default-members = [
     "generate",
     "ste",
 ]
-
-[patch.'https://github.com/udoprog/audio']
-audio = { path = "audio" }
-audio-core = { path = "audio-core" }


### PR DESCRIPTION
This isn't used by any crates in the workspace.