### PR TITLE
Export buffer adapters from audio_core

### DIFF
--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::should_implement_trait)]
 
 pub mod buf;
-pub use self::buf::Buf;
+pub use self::buf::*;
 
 mod buf_mut;
 pub use self::buf_mut::BufMut;


### PR DESCRIPTION
I noticed this trying to use the Limit struct returned by Buf::limit.