### PR TITLE
Implement Sample for byte arrays

### DIFF
--- a/audio-core/src/sample.rs
+++ b/audio-core/src/sample.rs
@@ -70,7 +70,6 @@ impl_int!(i128);
 impl_int!(usize);
 impl_int!(isize);
 
-
 // Helper macro to implement [Sample] for byte arrays.
 macro_rules! impl_bytes {
     ($bytes:expr) => {

--- a/audio-core/src/sample.rs
+++ b/audio-core/src/sample.rs
@@ -10,7 +10,7 @@
 ///
 /// Implementor must make sure that a bit-pattern of all-zeros is a legal
 /// bit-pattern for the implemented type.
-pub unsafe trait Sample: Copy + Default {
+pub unsafe trait Sample: Copy {
     /// The zero pattern for the sample.
     const ZERO: Self;
 }
@@ -70,18 +70,7 @@ impl_int!(i128);
 impl_int!(usize);
 impl_int!(isize);
 
-// Helper macro to implement [Sample] for byte arrays.
-macro_rules! impl_bytes {
-    ($bytes:expr) => {
-        unsafe impl Sample for [u8; $bytes] {
-            const ZERO: Self = [0; $bytes];
-        }
-    };
+// Implement for byte arrays of any length
+unsafe impl<const N: usize> Sample for [u8; N] {
+    const ZERO: Self = [0; N];
 }
-
-// Implement for byte arrays of common lengths
-impl_bytes!(2);
-impl_bytes!(3);
-impl_bytes!(4);
-impl_bytes!(8);
-impl_bytes!(16);

--- a/audio-core/src/sample.rs
+++ b/audio-core/src/sample.rs
@@ -69,3 +69,20 @@ impl_int!(i64);
 impl_int!(i128);
 impl_int!(usize);
 impl_int!(isize);
+
+
+// Helper macro to implement [Sample] for byte arrays.
+macro_rules! impl_bytes {
+    ($bytes:expr) => {
+        unsafe impl Sample for [u8; $bytes] {
+            const ZERO: Self = [0; $bytes];
+        }
+    };
+}
+
+// Implement for byte arrays of common lengths
+impl_bytes!(2);
+impl_bytes!(3);
+impl_bytes!(4);
+impl_bytes!(8);
+impl_bytes!(16);

--- a/audio/src/tests/byte_arrays.rs
+++ b/audio/src/tests/byte_arrays.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_byte_array() {
-
-    let buf: crate::buf::Interleaved<[u8; 2]> = crate::interleaved![[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+    let buf: crate::buf::Interleaved<[u8; 2]> =
+        crate::interleaved![[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
 
     assert_eq!(buf.channels(), 2);
     assert_eq!(buf.sample(0, 0).unwrap(), [1, 2]);

--- a/audio/src/tests/byte_arrays.rs
+++ b/audio/src/tests/byte_arrays.rs
@@ -1,0 +1,11 @@
+#[test]
+fn test_byte_array() {
+
+    let buf: crate::buf::Interleaved<[u8; 2]> = crate::interleaved![[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+
+    assert_eq!(buf.channels(), 2);
+    assert_eq!(buf.sample(0, 0).unwrap(), [1, 2]);
+    assert_eq!(buf.sample(0, 1).unwrap(), [3, 4]);
+    assert_eq!(buf.sample(1, 0).unwrap(), [5, 6]);
+    assert_eq!(buf.sample(1, 1).unwrap(), [7, 8]);
+}

--- a/audio/src/tests/mod.rs
+++ b/audio/src/tests/mod.rs
@@ -1,6 +1,6 @@
+mod byte_arrays;
 mod copy_channel;
 mod dynamic;
 mod interleaved;
 mod io;
 mod sequential;
-mod byte_arrays;

--- a/audio/src/tests/mod.rs
+++ b/audio/src/tests/mod.rs
@@ -3,3 +3,4 @@ mod dynamic;
 mod interleaved;
 mod io;
 mod sequential;
+mod byte_arrays;


### PR DESCRIPTION
This implements the Sample trait for byte arrays of length 2, 3, 4, 8 and 16, which should cover the byte representation of all common numerical formats. I added a simple test to show it working, not sure if it's placed where it belongs.  